### PR TITLE
Add Supabase client setup and dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.56.1",
     "@types/react-router-dom": "^5.3.3",
     "lucide-react": "^1.14.0",
     "react": "^18.2.0",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables: VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
### Motivation
- Provide a shared Supabase client and package dependency so the app can connect to Supabase using Vite environment variables.

### Description
- Add `@supabase/supabase-js` to `package.json` and create `src/lib/supabase.ts` which imports `createClient`, reads `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`, throws if they are missing, and exports `supabase`; note that pushing to `origin/main` failed in this environment due to a network/proxy 403.

### Testing
- Verified file and dependency presence with `test -f src/lib/supabase.ts` and `node -e "const p=require('./package.json'); console.log(p.dependencies['@supabase/supabase-js'])"`, and successfully staged and committed the changes, while `npm install --package-lock-only` failed with a `403 Forbidden` from the npm registry and `git push` failed with `CONNECT tunnel failed, response 403`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f381cf3f14832bbcdf4e65f6b4ea02)