### PR TITLE
Keep /login in member flow and prevent automatic admin redirects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,13 @@ function RequireAuth({
   return <>{children}</>
 }
 
+/** Redirect logged-in users to member app (never force admin from /login flow). */
+function RedirectIfAuthedToMember({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
+  if (user) return <Navigate to="/farmer" replace />
+  return <>{children}</>
+}
+
 /** Redirect to role home when already logged in */
 function RedirectIfAuthed({ children }: { children: React.ReactNode }) {
   const { user } = useAuth()
@@ -122,9 +129,9 @@ export default function App() {
 
           {/* ── Public ── */}
           <Route path="/"            element={<Navigate to="/login" replace />} />
-          <Route path="/login"       element={<RedirectIfAuthed><LoginLanding /></RedirectIfAuthed>} />
-          <Route path="/register"    element={<RedirectIfAuthed><RegisterFlow /></RedirectIfAuthed>} />
-          <Route path="/signin"      element={<RedirectIfAuthed><SignIn /></RedirectIfAuthed>} />
+          <Route path="/login"       element={<RedirectIfAuthedToMember><LoginLanding /></RedirectIfAuthedToMember>} />
+          <Route path="/register"    element={<RedirectIfAuthedToMember><RegisterFlow /></RedirectIfAuthedToMember>} />
+          <Route path="/signin"      element={<RedirectIfAuthedToMember><SignIn /></RedirectIfAuthedToMember>} />
           <Route path="/admin-login" element={<RedirectIfAuthed><AdminLogin /></RedirectIfAuthed>} />
 
           {/* ── Farmer / Member — LINE Mini App ── */}

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -37,7 +37,7 @@ export default function SignIn() {
       login(res.data)   // persist ใน localStorage ผ่าน AuthContext
 
       // route ตาม role
-      if (res.data.role === 'admin') navigate('/admin', { replace: true })
+      if (res.data.role === 'admin') navigate('/farmer', { replace: true })
       else if (res.data.role === 'leader') navigate('/leader', { replace: true })
       else if (res.data.role === 'inspector') navigate('/inspector', { replace: true })
       else navigate('/farmer', { replace: true })


### PR DESCRIPTION
### Motivation

- Prevent the public/member login flow from automatically redirecting authenticated admins into the admin console, so admin access remains explicit and separate.
- Ensure `/login`/`/register`/`/signin` always land in the member app context (LINE mini app) and do not force web admin navigation.

### Description

- Added a new guard `RedirectIfAuthedToMember` that always redirects authenticated users to the member app (`/farmer`) instead of performing role-based admin redirects.
- Updated public routes so `/login`, `/register`, and `/signin` use `RedirectIfAuthedToMember` while leaving `/admin-login` using the existing `RedirectIfAuthed` guard.
- Updated the sign-in flow in `src/routes/SignIn.tsx` so a user with `role === 'admin'` who signs in from the member sign-in path is routed to `/farmer` rather than `/admin`.
- Changed files: `src/App.tsx` and `src/routes/SignIn.tsx` to implement the above behavior.

### Testing

- Ran `npm run build` which completed successfully (TypeScript compile + Vite production build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5dc298d20832bbbdc72ffed90b258)