### PR TITLE
Admin: Add CRUD UI for Seed Suppliers and Seed Varieties

### DIFF
--- a/src/app/admin/AdminSeedSuppliers.tsx
+++ b/src/app/admin/AdminSeedSuppliers.tsx
@@ -1,21 +1,64 @@
-import React from 'react'
-import { Construction } from 'lucide-react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { createSeedSupplier, fetchSeedSuppliers, type SeedSupplier, type SeedSupplierPayload, updateSeedSupplier } from '../../lib/db'
+
+const emptyForm: SeedSupplierPayload = { supplier_name: '', seed_brand: '', contact_name: '', phone: '', address: '', contract_terms: '', active_status: true, show_to_farmer: true }
 
 export default function AdminSeedSuppliers() {
-  return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <span className="text-3xl">🏪</span>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Supplier เมล็ดพันธุ์</h1>
-          <p className="text-gray-500 text-sm mt-0.5">จัดการข้อมูล Supplier เมล็ดพันธุ์</p>
-        </div>
+  const [items, setItems] = useState<SeedSupplier[]>([])
+  const [search, setSearch] = useState('')
+  const [form, setForm] = useState<SeedSupplierPayload>(emptyForm)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = async () => {
+    const res = await fetchSeedSuppliers()
+    if (res.error) setErr(`โหลดข้อมูลไม่สำเร็จ: ${res.error}`)
+    setItems(res.data ?? [])
+  }
+  useEffect(() => { load() }, [])
+
+  const filtered = useMemo(() => items.filter(s => [s.supplier_name, s.seed_brand, s.contact_name, s.phone].join(' ').toLowerCase().includes(search.toLowerCase())), [items, search])
+
+  const onSave = async () => {
+    if (!form.supplier_name?.trim()) return setErr('กรุณากรอกชื่อ Supplier')
+    setErr(null)
+    const res = editingId ? await updateSeedSupplier(editingId, form) : await createSeedSupplier(form)
+    if (res.error) return setErr(`บันทึกไม่สำเร็จ: ${res.error}`)
+    setMsg(editingId ? 'แก้ไข Supplier สำเร็จ' : 'เพิ่ม Supplier สำเร็จ')
+    setEditingId(null)
+    setForm(emptyForm)
+    await load()
+  }
+
+  return <div className="space-y-4">
+    <div><h1 className="text-2xl font-bold">Supplier เมล็ดพันธุ์</h1><p className="text-sm text-gray-500">จัดการข้อมูล Supplier เมล็ดพันธุ์ ผู้ติดต่อ และเบอร์โทรสำหรับเกษตรกร</p></div>
+    <div className="grid grid-cols-3 gap-3">
+      <Card title="Supplier ทั้งหมด" value={items.length} />
+      <Card title="ใช้งานอยู่" value={items.filter(i => i.active_status).length} />
+      <Card title="แสดงให้เกษตรกรเห็น" value={items.filter(i => i.show_to_farmer).length} />
+    </div>
+    {msg && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-emerald-700 text-sm">{msg}</div>}
+    {err && <div className="bg-red-50 border border-red-300 p-2 rounded text-red-700 text-sm">{err}</div>}
+    <div className="bg-white rounded-xl border p-4 space-y-3">
+      <input className="w-full border rounded px-3 py-2" placeholder="ค้นหา supplier_name, seed_brand, contact_name, phone" value={search} onChange={e => setSearch(e.target.value)} />
+      <div className="grid md:grid-cols-2 gap-2">
+        {['supplier_name','seed_brand','contact_name','phone','address','contract_terms'].map((f) => (
+          <input key={f} className="border rounded px-3 py-2" placeholder={f} value={String(form[f as keyof SeedSupplierPayload] ?? '')} onChange={e => setForm(prev => ({ ...prev, [f]: e.target.value }))} />
+        ))}
+        <label><input type="checkbox" checked={!!form.active_status} onChange={e => setForm(prev => ({ ...prev, active_status: e.target.checked }))} /> สถานะใช้งาน</label>
+        <label><input type="checkbox" checked={!!form.show_to_farmer} onChange={e => setForm(prev => ({ ...prev, show_to_farmer: e.target.checked }))} /> แสดงให้เกษตรกร</label>
       </div>
-      <div className="bg-white rounded-2xl border-2 border-dashed border-gray-200 p-16 text-center">
-        <Construction className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h2 className="text-lg font-semibold text-gray-400 mb-2">กำลังพัฒนา</h2>
-        <p className="text-gray-400 text-sm">หน้านี้อยู่ระหว่างการพัฒนา</p>
+      <div className="flex gap-2">
+        <button onClick={() => { setEditingId(null); setForm(emptyForm) }} className="px-4 py-2 border rounded">ล้างฟอร์ม</button>
+        <button onClick={onSave} className="px-4 py-2 bg-emerald-600 text-white rounded">{editingId ? 'บันทึกการแก้ไข' : 'เพิ่ม Supplier'}</button>
       </div>
     </div>
-  )
+    <div className="bg-white rounded-xl border overflow-auto">
+      <table className="w-full text-sm"><thead><tr className="bg-gray-50 text-left"><th className="p-2">Supplier</th><th>Brand</th><th>ผู้ติดต่อ</th><th>เบอร์โทร</th><th>สถานะใช้งาน</th><th>แสดงให้เกษตรกร</th><th>Actions</th></tr></thead>
+      <tbody>{filtered.map(i => <tr key={i.id} className="border-t"><td className="p-2">{i.supplier_name}</td><td>{i.seed_brand}</td><td>{i.contact_name}</td><td>{i.phone}</td><td>{i.active_status ? 'เปิด' : 'ปิด'}</td><td>{i.show_to_farmer ? 'แสดง' : 'ซ่อน'}</td><td><button className="text-blue-600" onClick={() => { setEditingId(i.id); setForm(i) }}>แก้ไข</button></td></tr>)}</tbody></table>
+    </div>
+  </div>
 }
+
+function Card({ title, value }: { title: string, value: number }) { return <div className="bg-white border rounded-xl p-3"><div className="text-gray-500 text-sm">{title}</div><div className="font-bold text-2xl">{value}</div></div> }

--- a/src/app/admin/AdminSeedVarieties.tsx
+++ b/src/app/admin/AdminSeedVarieties.tsx
@@ -1,21 +1,59 @@
-import React from 'react'
-import { Construction } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { createSeedVariety, fetchSeedSuppliers, fetchSeedVarieties, type SeedSupplier, type SeedVariety, type SeedVarietyPayload, updateSeedVariety } from '../../lib/db'
+
+const emptyForm: SeedVarietyPayload = { supplier_id: '', variety_name: '', brand: '', bag_weight_kg: null, price_per_bag: null, unit: 'bag', maturity_days: null, recommended_area: '', soil_requirement: '', water_requirement: '', disease_resistance: '', planting_spacing: '', fertilizer_recommendation: '', restrictions: '', planting_steps: '', expected_yield: '', active_status: true, show_to_farmer: true }
 
 export default function AdminSeedVarieties() {
-  return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <span className="text-3xl">🌾</span>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">พันธุ์เมล็ดพันธุ์</h1>
-          <p className="text-gray-500 text-sm mt-0.5">จัดการข้อมูล พันธุ์เมล็ดพันธุ์</p>
-        </div>
+  const [suppliers, setSuppliers] = useState<SeedSupplier[]>([])
+  const [rows, setRows] = useState<SeedVariety[]>([])
+  const [search, setSearch] = useState('')
+  const [supplierId, setSupplierId] = useState('')
+  const [form, setForm] = useState<SeedVarietyPayload>(emptyForm)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = async () => {
+    const [s, v] = await Promise.all([fetchSeedSuppliers(), fetchSeedVarieties({ supplierId: supplierId || undefined, search: search || undefined })])
+    setSuppliers(s.data ?? [])
+    setRows(v.data ?? [])
+    if (s.error || v.error) setErr(`โหลดข้อมูลไม่สำเร็จ: ${s.error ?? v.error}`)
+  }
+  useEffect(() => { load() }, [supplierId, search])
+
+  const save = async () => {
+    if (!form.supplier_id) return setErr('กรุณาเลือก Supplier')
+    if (!suppliers.some(s => s.id === form.supplier_id)) return setErr('Supplier ไม่ถูกต้อง')
+    if (!form.variety_name?.trim()) return setErr('กรุณากรอกชื่อพันธุ์')
+    const res = editingId ? await updateSeedVariety(editingId, form) : await createSeedVariety(form)
+    if (res.error) return setErr(`บันทึกไม่สำเร็จ: ${res.error}`)
+    setMsg(editingId ? 'แก้ไขพันธุ์เมล็ดพันธุ์สำเร็จ' : 'เพิ่มพันธุ์เมล็ดพันธุ์สำเร็จ')
+    setEditingId(null); setForm(emptyForm); setErr(null); await load()
+  }
+
+  return <div className="space-y-4">
+    <div><h1 className="text-2xl font-bold">พันธุ์เมล็ดพันธุ์</h1><p className="text-sm text-gray-500">กำหนดชื่อพันธุ์ ขนาดถุง ราคา และข้อจำกัดการปลูก</p></div>
+    {msg && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-sm text-emerald-700">{msg}</div>}
+    {err && <div className="bg-red-50 border border-red-300 p-2 rounded text-sm text-red-700">{err}</div>}
+    <div className="bg-white rounded-xl border p-4 space-y-3">
+      <div className="grid md:grid-cols-2 gap-2">
+        <select className="border rounded px-3 py-2" value={supplierId} onChange={e => setSupplierId(e.target.value)}><option value="">ทุก Supplier</option>{suppliers.map(s => <option key={s.id} value={s.id}>{s.supplier_name}</option>)}</select>
+        <input className="border rounded px-3 py-2" placeholder="ค้นหา variety_name / brand" value={search} onChange={e => setSearch(e.target.value)} />
       </div>
-      <div className="bg-white rounded-2xl border-2 border-dashed border-gray-200 p-16 text-center">
-        <Construction className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h2 className="text-lg font-semibold text-gray-400 mb-2">กำลังพัฒนา</h2>
-        <p className="text-gray-400 text-sm">หน้านี้อยู่ระหว่างการพัฒนา</p>
+      <div className="grid md:grid-cols-3 gap-2">
+        <select className="border rounded px-3 py-2" value={form.supplier_id} onChange={e => setForm(f => ({ ...f, supplier_id: e.target.value }))}><option value="">เลือก Supplier</option>{suppliers.map(s => <option key={s.id} value={s.id}>{s.supplier_name}</option>)}</select>
+        <input className="border rounded px-3 py-2" placeholder="variety_name" value={form.variety_name} onChange={e => setForm(f => ({ ...f, variety_name: e.target.value }))} />
+        <input className="border rounded px-3 py-2" placeholder="brand" value={form.brand ?? ''} onChange={e => setForm(f => ({ ...f, brand: e.target.value }))} />
+        <input type="number" className="border rounded px-3 py-2" placeholder="bag_weight_kg" value={form.bag_weight_kg ?? ''} onChange={e => setForm(f => ({ ...f, bag_weight_kg: e.target.value ? Number(e.target.value) : null }))} />
+        <input type="number" className="border rounded px-3 py-2" placeholder="price_per_bag" value={form.price_per_bag ?? ''} onChange={e => setForm(f => ({ ...f, price_per_bag: e.target.value ? Number(e.target.value) : null }))} />
+        <input className="border rounded px-3 py-2" placeholder="unit" value={form.unit ?? 'bag'} onChange={e => setForm(f => ({ ...f, unit: e.target.value }))} />
+        <input type="number" className="border rounded px-3 py-2" placeholder="maturity_days" value={form.maturity_days ?? ''} onChange={e => setForm(f => ({ ...f, maturity_days: e.target.value ? Number(e.target.value) : null }))} />
+        {['recommended_area','soil_requirement','water_requirement','disease_resistance','planting_spacing','fertilizer_recommendation','restrictions','planting_steps','expected_yield'].map(k => <input key={k} className="border rounded px-3 py-2" placeholder={k} value={String(form[k as keyof SeedVarietyPayload] ?? '')} onChange={e => setForm(f => ({ ...f, [k]: e.target.value }))} />)}
+        <label><input type="checkbox" checked={!!form.active_status} onChange={e => setForm(f => ({ ...f, active_status: e.target.checked }))} /> เปิดใช้งาน</label>
+        <label><input type="checkbox" checked={!!form.show_to_farmer} onChange={e => setForm(f => ({ ...f, show_to_farmer: e.target.checked }))} /> แสดงให้เกษตรกร</label>
       </div>
+      <button onClick={save} className="px-4 py-2 bg-emerald-600 text-white rounded">{editingId ? 'บันทึกการแก้ไข' : 'เพิ่มพันธุ์'}</button>
     </div>
-  )
+    <div className="bg-white rounded-xl border overflow-auto"><table className="w-full text-sm"><thead><tr className="bg-gray-50"><th className="p-2 text-left">Supplier</th><th>ชื่อพันธุ์</th><th>Brand</th><th>kg/ถุง</th><th>ราคาต่อถุง</th><th>อายุเก็บเกี่ยว</th><th>เปิดใช้งาน</th><th>แสดงให้เกษตรกร</th><th>Actions</th></tr></thead><tbody>{rows.map(r => <tr key={r.id} className="border-t"><td className="p-2">{r.supplier_name}</td><td>{r.variety_name}</td><td>{r.brand}</td><td>{r.bag_weight_kg ?? '-'}</td><td>{r.price_per_bag ?? '-'}</td><td>{r.maturity_days ?? '-'}</td><td>{r.active_status ? 'เปิด' : 'ปิด'}</td><td>{r.show_to_farmer ? 'แสดง' : 'ซ่อน'}</td><td><button className="text-blue-600" onClick={() => { setEditingId(r.id); setForm({ ...r }) }}>แก้ไข</button></td></tr>)}</tbody></table></div>
+  </div>
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1023,3 +1023,153 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
     return 'inserted'
   }
 }
+
+export interface SeedSupplier {
+  id: string
+  supplier_name: string
+  seed_brand: string | null
+  contact_name: string | null
+  phone: string | null
+  address: string | null
+  contract_terms: string | null
+  active_status: boolean
+  show_to_farmer: boolean
+}
+
+export interface SeedSupplierPayload {
+  supplier_name: string
+  seed_brand?: string | null
+  contact_name?: string | null
+  phone?: string | null
+  address?: string | null
+  contract_terms?: string | null
+  active_status?: boolean
+  show_to_farmer?: boolean
+}
+
+export interface SeedVariety {
+  id: string
+  supplier_id: string
+  supplier_name?: string | null
+  variety_name: string
+  brand: string | null
+  bag_weight_kg: number | null
+  price_per_bag: number | null
+  unit: string | null
+  maturity_days: number | null
+  recommended_area: string | null
+  soil_requirement: string | null
+  water_requirement: string | null
+  disease_resistance: string | null
+  planting_spacing: string | null
+  fertilizer_recommendation: string | null
+  restrictions: string | null
+  planting_steps: string | null
+  expected_yield: string | null
+  active_status: boolean
+  show_to_farmer: boolean
+}
+
+export interface SeedVarietyPayload {
+  supplier_id: string
+  variety_name: string
+  brand?: string | null
+  bag_weight_kg?: number | null
+  price_per_bag?: number | null
+  unit?: string | null
+  maturity_days?: number | null
+  recommended_area?: string | null
+  soil_requirement?: string | null
+  water_requirement?: string | null
+  disease_resistance?: string | null
+  planting_spacing?: string | null
+  fertilizer_recommendation?: string | null
+  restrictions?: string | null
+  planting_steps?: string | null
+  expected_yield?: string | null
+  active_status?: boolean
+  show_to_farmer?: boolean
+}
+
+export async function fetchSeedSuppliers(): Promise<DbResult<SeedSupplier[]>> {
+  if (!supabase) return { data: [], error: null, source: 'mock' }
+  const { data, error } = await supabase.from('seed_suppliers').select('*').order('supplier_name')
+  if (error) {
+    logSupabaseError('fetchSeedSuppliers', error)
+    return { data: [], error: error.message, source: 'supabase' }
+  }
+  return { data: (data ?? []) as SeedSupplier[], error: null, source: 'supabase' }
+}
+
+export async function createSeedSupplier(payload: SeedSupplierPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id: `mock-${Date.now()}` }, error: null, source: 'mock' }
+  const { data, error } = await supabase.from('seed_suppliers').insert(payload).select('id').single()
+  if (error) logSupabaseError('createSeedSupplier', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}
+
+export async function updateSeedSupplier(id: string, payload: SeedSupplierPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id }, error: null, source: 'mock' }
+  const { data, error } = await supabase.from('seed_suppliers').update(payload).eq('id', id).select('id').single()
+  if (error) logSupabaseError('updateSeedSupplier', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}
+
+export async function fetchSeedVarieties(filters?: { supplierId?: string; search?: string }): Promise<DbResult<SeedVariety[]>> {
+  if (!supabase) return { data: [], error: null, source: 'mock' }
+  let query = supabase.from('seed_varieties').select('*, seed_suppliers:supplier_id (supplier_name)').order('created_at', { ascending: false })
+  if (filters?.supplierId) query = query.eq('supplier_id', filters.supplierId)
+  if (filters?.search) {
+    query = query.or(`variety_name.ilike.%${filters.search}%,brand.ilike.%${filters.search}%`)
+  }
+  const { data, error } = await query
+  if (error) {
+    logSupabaseError('fetchSeedVarieties', error)
+    return { data: [], error: error.message, source: 'supabase' }
+  }
+  const mapped = (data ?? []).map((row: Record<string, unknown>) => ({
+    id: String(row.id ?? ''),
+    supplier_id: String(row.supplier_id ?? ''),
+    supplier_name: (row.seed_suppliers as { supplier_name?: string } | null)?.supplier_name ?? null,
+    variety_name: String(row.variety_name ?? ''),
+    brand: (row.brand as string | null) ?? null,
+    bag_weight_kg: (row.bag_weight_kg as number | null) ?? null,
+    price_per_bag: (row.price_per_bag as number | null) ?? null,
+    unit: (row.unit as string | null) ?? null,
+    maturity_days: (row.maturity_days as number | null) ?? null,
+    recommended_area: (row.recommended_area as string | null) ?? null,
+    soil_requirement: (row.soil_requirement as string | null) ?? null,
+    water_requirement: (row.water_requirement as string | null) ?? null,
+    disease_resistance: (row.disease_resistance as string | null) ?? null,
+    planting_spacing: (row.planting_spacing as string | null) ?? null,
+    fertilizer_recommendation: (row.fertilizer_recommendation as string | null) ?? null,
+    restrictions: (row.restrictions as string | null) ?? null,
+    planting_steps: (row.planting_steps as string | null) ?? null,
+    expected_yield: (row.expected_yield as string | null) ?? null,
+    active_status: Boolean(row.active_status),
+    show_to_farmer: Boolean(row.show_to_farmer),
+  }))
+  return { data: mapped as SeedVariety[], error: null, source: 'supabase' }
+}
+
+export async function fetchSeedVarietiesBySupplier(supplierId: string): Promise<DbResult<SeedVariety[]>> {
+  return fetchSeedVarieties({ supplierId })
+}
+
+export async function createSeedVariety(payload: SeedVarietyPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id: `mock-${Date.now()}` }, error: null, source: 'mock' }
+  const { data: supplierExists } = await supabase.from('seed_suppliers').select('id').eq('id', payload.supplier_id).maybeSingle()
+  if (!supplierExists) return { data: null, error: 'ไม่พบ Supplier ที่เลือก', source: 'supabase' }
+  const { data, error } = await supabase.from('seed_varieties').insert(payload).select('id').single()
+  if (error) logSupabaseError('createSeedVariety', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}
+
+export async function updateSeedVariety(id: string, payload: SeedVarietyPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id }, error: null, source: 'mock' }
+  const { data: supplierExists } = await supabase.from('seed_suppliers').select('id').eq('id', payload.supplier_id).maybeSingle()
+  if (!supplierExists) return { data: null, error: 'ไม่พบ Supplier ที่เลือก', source: 'supabase' }
+  const { data, error } = await supabase.from('seed_varieties').update(payload).eq('id', id).select('id').single()
+  if (error) logSupabaseError('updateSeedVariety', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}


### PR DESCRIPTION
### Motivation
- Provide admin users web UI to create, edit and list seed suppliers and seed varieties instead of running SQL directly. 
- Persist `bag_weight_kg` and `price_per_bag` for downstream stock and sales flows and expose supplier join data for display. 

### Description
- Added Supabase data layer and types in `src/lib/db.ts`, including `SeedSupplier` / `SeedVariety` types and functions `fetchSeedSuppliers`, `createSeedSupplier`, `updateSeedSupplier`, `fetchSeedVarieties`, `fetchSeedVarietiesBySupplier`, `createSeedVariety`, and `updateSeedVariety`, with supplier existence validation and supplier-name join. 
- Implemented admin supplier page at `/admin/seed-suppliers` in `src/app/admin/AdminSeedSuppliers.tsx` with Thai header/subtitle, summary cards, search (by `supplier_name`, `seed_brand`, `contact_name`, `phone`), table columns, and add/edit form that saves to `seed_suppliers` and shows Thai success/error messages. 
- Implemented admin variety page at `/admin/seed-varieties` in `src/app/admin/AdminSeedVarieties.tsx` with Thai header/subtitle, supplier filter dropdown, search (by `variety_name` / `brand`), table columns, and full add/edit form fields (including `bag_weight_kg`, `price_per_bag`, `unit`, maturity and cultivation fields) that save to `seed_varieties` and validate `supplier_id` before save. 
- Added client-side mapping of Supabase rows to typed `SeedVariety` objects and boolean coercion for flags to satisfy TypeScript and ensure stable UI values. 

### Testing
- Built the project with `npm run build` (TypeScript compile + Vite build) and the production build completed successfully. 
- Fixed a TypeScript mapping issue during implementation so the build no longer reports incorrect casts; the build step passed after the fix. 
- No unit tests were added; validation performed via the TypeScript compiler and the production build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5e63ece88832bb223dd89b7599663)