### PR TITLE
Fix profile/farmer/provider schema and LIFF LINE identity handling

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,6 +17,7 @@ export interface DbResult<T> {
 // ── Schema types (column names ตรงกับ Supabase) ───────────────────────────────
 
 export interface ProfileInsert {
+  line_user_id?: string
   line_uid?: string
   full_name: string
   phone: string
@@ -599,6 +600,15 @@ export async function loginWithIdCardPhone(
   }
 }
 
+export async function saveProfileLineUserId(profileId: string, lineUserId: string): Promise<void> {
+  if (!supabase || !profileId || !lineUserId) return
+  const { error } = await supabase
+    .from('profiles')
+    .update({ line_user_id: lineUserId, line_uid: lineUserId })
+    .eq('id', profileId)
+  if (error) throw error
+}
+
 /** สมัครสมาชิก: check dup → upsert profile → insert farmer */
 export async function registerFarmerMember(
   payload: RegisterPayload
@@ -890,6 +900,33 @@ export interface MemberAdminFields {
   status?: string
 }
 
+function isServiceProviderRole(role?: string) {
+  return role === 'harvester' || role === 'tractor' || role === 'truck'
+}
+
+async function ensureFarmerFromProfile(profileId: string, status = 'pending_leader') {
+  if (!supabase) return
+  const { data: existing } = await supabase.from('farmers').select('id').eq('profile_id', profileId).maybeSingle()
+  if (existing) return
+  const { error } = await supabase.from('farmers').insert({ profile_id: profileId, status, member_status: status, role: 'member' })
+  if (error) throw error
+}
+
+async function ensureServiceProviderFromProfile(profileId: string, role: string) {
+  if (!supabase) return
+  const { data: existing } = await supabase.from('service_providers').select('id').eq('profile_id', profileId).eq('provider_type', role).maybeSingle()
+  if (existing) return
+  const { data: profile } = await supabase.from('profiles').select('full_name, grade, sub_role').eq('id', profileId).maybeSingle()
+  const { error } = await supabase.from('service_providers').insert({
+    profile_id: profileId,
+    provider_type: role,
+    provider_name: profile?.full_name ?? null,
+    sub_role: profile?.sub_role ?? null,
+    grade: profile?.grade ?? 'C',
+  })
+  if (error) throw error
+}
+
 export async function updateMemberAdminFields(
   id: string,
   payload: MemberAdminFields
@@ -909,6 +946,22 @@ export async function updateMemberAdminFields(
     if (error) {
       logSupabaseError('updateMemberAdminFields:profiles', error)
       throw new Error(error.message)
+    }
+  }
+
+  if (role === 'farmer') {
+    try {
+      await ensureFarmerFromProfile(id, status ?? 'pending_leader')
+    } catch (error) {
+      logSupabaseError('updateMemberAdminFields:ensureFarmer', error as { message: string; code?: string; details?: string })
+      throw error
+    }
+  } else if (isServiceProviderRole(role)) {
+    try {
+      await ensureServiceProviderFromProfile(id, role)
+    } catch (error) {
+      logSupabaseError('updateMemberAdminFields:ensureServiceProvider', error as { message: string; code?: string; details?: string })
+      throw error
     }
   }
 
@@ -968,6 +1021,9 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
       grade:     row.grade || 'C',
     }).eq('id', exist.id)
 
+    if (row.role === 'farmer') await ensureFarmerFromProfile(exist.id, row.status || 'pending_leader')
+    if (isServiceProviderRole(row.role)) await ensureServiceProviderFromProfile(exist.id, row.role)
+
     // update farmers (upsert ถ้าไม่มี row)
     const { data: f } = await supabase.from('farmers').select('id').eq('profile_id', exist.id).maybeSingle()
     if (f) {
@@ -1008,7 +1064,9 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
     }).select('id').single()
     if (pe) throw new Error(pe.message)
 
-    await supabase.from('farmers').insert({
+    if (row.role === 'farmer') await ensureFarmerFromProfile(p.id, row.status || 'pending_leader')
+    if (isServiceProviderRole(row.role)) await ensureServiceProviderFromProfile(p.id, row.role)
+    await supabase.from('farmers').upsert({
       profile_id:       p.id,
       province:         row.province,
       district:         row.district,
@@ -1017,9 +1075,10 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
       bank_account_no:  row.bank_account_no,
       bank_account_name:row.bank_account_name,
       status:           row.status || 'pending_line_verify',
+      member_status:    row.status || 'pending_line_verify',
       total_area:       0,
       tier:             'bronze',
-    })
+    }, { onConflict: 'profile_id' })
     return 'inserted'
   }
 }

--- a/src/routes/RegisterFlow.tsx
+++ b/src/routes/RegisterFlow.tsx
@@ -5,7 +5,7 @@ import {
   User, CreditCard, Phone, MapPin, Building2,
 } from 'lucide-react'
 import { useAuth } from './AuthContext'
-import { registerFarmerMember } from '../lib/db'
+import { registerFarmerMember, saveProfileLineUserId } from '../lib/db'
 import { isSupabaseReady } from '../lib/supabase'
 
 const PROVINCES = ['บุรีรัมย์','สุรินทร์','ศรีสะเกษ','นครราชสีมา','ร้อยเอ็ด','อุบลราชธานี','ยโสธร','มุกดาหาร']
@@ -103,6 +103,11 @@ export default function RegisterFlow() {
       if (res.error && isSupabaseReady) throw new Error(res.error)
       setStep('สมัครสำเร็จ! ✓')
       if (res.data) {
+        const lineUserId = new URLSearchParams(window.location.search).get('line_user_id')
+          || new URLSearchParams(window.location.search).get('userId')
+        if (lineUserId) {
+          await saveProfileLineUserId(res.data.profileId, lineUserId)
+        }
         login(res.data)
         navigate('/farmer', { replace: true })
       }

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChevronLeft, CreditCard, Phone, RefreshCw, AlertCircle, Eye, EyeOff } from 'lucide-react'
 import { useAuth } from './AuthContext'
-import { loginWithIdCardPhone } from '../lib/db'
+import { loginWithIdCardPhone, saveProfileLineUserId } from '../lib/db'
 import { isSupabaseReady } from '../lib/supabase'
 
 export default function SignIn() {
@@ -35,6 +35,11 @@ export default function SignIn() {
       }
 
       login(res.data)   // persist ใน localStorage ผ่าน AuthContext
+      const lineUserId = new URLSearchParams(window.location.search).get('line_user_id')
+        || new URLSearchParams(window.location.search).get('userId')
+      if (lineUserId) {
+        await saveProfileLineUserId(res.data.profileId, lineUserId)
+      }
 
       // route ตาม role
       if (res.data.role === 'admin') navigate('/farmer', { replace: true })

--- a/src/supabase/migrations/fix_profile_role_permission_and_line_identity.sql
+++ b/src/supabase/migrations/fix_profile_role_permission_and_line_identity.sql
@@ -1,0 +1,45 @@
+-- Ensure profiles schema for role/permission and LINE identity
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS grade text DEFAULT 'C',
+  ADD COLUMN IF NOT EXISTS line_user_id text,
+  ADD COLUMN IF NOT EXISTS line_uid text,
+  ADD COLUMN IF NOT EXISTS user_group text DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS sub_role text,
+  ADD COLUMN IF NOT EXISTS department_role text,
+  ADD COLUMN IF NOT EXISTS can_access_admin boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending_admin';
+
+ALTER TABLE profiles
+  ALTER COLUMN grade SET DEFAULT 'C',
+  ALTER COLUMN user_group SET DEFAULT 'pending',
+  ALTER COLUMN can_access_admin SET DEFAULT false,
+  ALTER COLUMN status SET DEFAULT 'pending_admin';
+
+-- Ensure farmers schema
+ALTER TABLE farmers
+  ADD COLUMN IF NOT EXISTS profile_id uuid,
+  ADD COLUMN IF NOT EXISTS grade text DEFAULT 'C',
+  ADD COLUMN IF NOT EXISTS role text DEFAULT 'member',
+  ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending_leader',
+  ADD COLUMN IF NOT EXISTS member_status text DEFAULT 'pending_leader';
+
+ALTER TABLE farmers
+  ALTER COLUMN grade SET DEFAULT 'C',
+  ALTER COLUMN role SET DEFAULT 'member',
+  ALTER COLUMN status SET DEFAULT 'pending_leader',
+  ALTER COLUMN member_status SET DEFAULT 'pending_leader';
+
+-- Ensure service_providers schema
+ALTER TABLE service_providers
+  ADD COLUMN IF NOT EXISTS profile_id uuid,
+  ADD COLUMN IF NOT EXISTS provider_type text,
+  ADD COLUMN IF NOT EXISTS provider_name text,
+  ADD COLUMN IF NOT EXISTS sub_role text,
+  ADD COLUMN IF NOT EXISTS grade text DEFAULT 'C',
+  ADD COLUMN IF NOT EXISTS can_inspect_farm boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS approved_by_admin boolean DEFAULT false;
+
+ALTER TABLE service_providers
+  ALTER COLUMN grade SET DEFAULT 'C',
+  ALTER COLUMN can_inspect_farm SET DEFAULT false,
+  ALTER COLUMN approved_by_admin SET DEFAULT false;


### PR DESCRIPTION
### Motivation
- Ensure DB schemas match admin/member flows by adding missing role/permission and LINE identity columns to `profiles`, `farmers`, and `service_providers` so admin UI and RLS/logic do not break. 
- Auto-provision associated rows when a `profile` is assigned a role (e.g., `farmer` or service-provider roles) to keep `profiles` + `farmers`/`service_providers` consistent. 
- Persist LINE identity when the app is opened via LIFF/query params so LINE-based flows can be tied to profiles. 

### Description
- Added a Supabase migration `src/supabase/migrations/fix_profile_role_permission_and_line_identity.sql` to add/ensure columns and defaults for `profiles` (`grade`, `line_user_id`, `line_uid`, `user_group`, `sub_role`, `department_role`, `can_access_admin`, `status`), `farmers` (`profile_id`, `grade`, `role`, `status`, `member_status`), and `service_providers` (`profile_id`, `provider_type`, `provider_name`, `sub_role`, `grade`, `can_inspect_farm`, `approved_by_admin`).
- Extended DB typings and APIs in `src/lib/db.ts` by adding `line_user_id` to `ProfileInsert`, implementing `saveProfileLineUserId(profileId, lineUserId)`, and adding helpers `isServiceProviderRole`, `ensureFarmerFromProfile`, and `ensureServiceProviderFromProfile` to auto-create `farmers` / `service_providers` rows as needed.
- Integrated auto-provisioning into admin/import flows by updating `updateMemberAdminFields` and `upsertMember` to call the new ensure-* helpers when a profile is assigned `farmer` or a service-provider role, and switched one insert to an upsert on `farmers` with `member_status` maintained.
- Wired LINE identity capture into UI flows by saving `line_user_id` (or `userId`) query params to the profile during sign-in and registration in `src/routes/SignIn.tsx` and `src/routes/RegisterFlow.tsx` using the new `saveProfileLineUserId` helper.

### Testing
- Ran `npm run build` (which executes `tsc && vite build`) and the build completed successfully with no TypeScript or bundling errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f602f733a0832b8bf101656fc195af)