### PR TITLE
Fix /admin/seed-sales to use real Supabase datasets and add reservation sale mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import MemberTier         from './app/farmer/MemberTier'
 import RegisterPage       from './app/farmer/RegisterPage'
 import RegistrationStatus from './app/farmer/RegistrationStatus'
 import SeedVarieties      from './app/farmer/SeedVarieties'
+import FarmerSeedVarieties from './app/farmer/FarmerSeedVarieties'
 
 // Leader
 import LeaderDashboard  from './app/leader/LeaderDashboard'
@@ -133,6 +134,7 @@ export default function App() {
             <Route path="status"   element={<RegistrationStatus />} />
             <Route path="register" element={<RegisterPage />} />
             <Route path="seeds"    element={<SeedVarieties />} />
+            <Route path="seed-varieties" element={<FarmerSeedVarieties />} />
             <Route path="prices"   element={<PriceAnnouncement />} />
             <Route path="tier"     element={<MemberTier />} />
             {/* farmer+ only */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,13 @@ function RequireAuth({
   return <>{children}</>
 }
 
+/** Redirect logged-in users to member app (never force admin from /login flow). */
+function RedirectIfAuthedToMember({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
+  if (user) return <Navigate to="/farmer" replace />
+  return <>{children}</>
+}
+
 /** Redirect to role home when already logged in */
 function RedirectIfAuthed({ children }: { children: React.ReactNode }) {
   const { user } = useAuth()
@@ -122,9 +129,9 @@ export default function App() {
 
           {/* ── Public ── */}
           <Route path="/"            element={<Navigate to="/login" replace />} />
-          <Route path="/login"       element={<RedirectIfAuthed><LoginLanding /></RedirectIfAuthed>} />
-          <Route path="/register"    element={<RedirectIfAuthed><RegisterFlow /></RedirectIfAuthed>} />
-          <Route path="/signin"      element={<RedirectIfAuthed><SignIn /></RedirectIfAuthed>} />
+          <Route path="/login"       element={<RedirectIfAuthedToMember><LoginLanding /></RedirectIfAuthedToMember>} />
+          <Route path="/register"    element={<RedirectIfAuthedToMember><RegisterFlow /></RedirectIfAuthedToMember>} />
+          <Route path="/signin"      element={<RedirectIfAuthedToMember><SignIn /></RedirectIfAuthedToMember>} />
           <Route path="/admin-login" element={<RedirectIfAuthed><AdminLogin /></RedirectIfAuthed>} />
 
           {/* ── Farmer / Member — LINE Mini App ── */}

--- a/src/app/admin/AdminRoles.tsx
+++ b/src/app/admin/AdminRoles.tsx
@@ -1,247 +1,115 @@
-import React, { useEffect, useState, useCallback } from 'react'
-import { RefreshCw, Check, AlertCircle, Wifi, WifiOff } from 'lucide-react'
-import { fetchAdminMembers, type AdminMemberRow } from '../../lib/db'
-import { isSupabaseReady, supabase } from '../../lib/supabase'
-import { DEPT_PERMISSIONS, type Department, type Permission } from '../../lib/permissions'
+import React, { useEffect, useMemo, useState } from 'react'
+import { Check, RefreshCw } from 'lucide-react'
+import { fetchFeatureCatalog, fetchRolePermissions, upsertRolePermission, type FeatureCatalogRow, type RolePermissionRow } from '../../lib/permissions'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../routes/AuthContext'
 
-const DEPARTMENTS: { value: Department; label: string; icon: string }[] = [
-  { value: 'agri',       label: 'ฝ่ายเกษตร',     icon: '🌱' },
-  { value: 'sales',      label: 'ฝ่ายขาย',       icon: '💰' },
-  { value: 'stock',      label: 'ฝ่ายสต็อก',     icon: '📦' },
-  { value: 'accounting', label: 'ฝ่ายบัญชี',     icon: '🧾' },
-  { value: 'inspection', label: 'ฝ่ายตรวจแปลง', icon: '🔍' },
-  { value: 'service',    label: 'ฝ่ายรถ/บริการ', icon: '🚜' },
-  { value: 'it',         label: 'ฝ่าย IT',       icon: '🔐' },
-]
+type MatrixRow = FeatureCatalogRow & Pick<RolePermissionRow, 'can_view' | 'can_create' | 'can_update' | 'can_approve'>
 
-const ALL_PERMS: { value: Permission; label: string; group: string }[] = [
-  { value: 'member.view',     label: 'ดูสมาชิก',           group: 'สมาชิก' },
-  { value: 'member.approve',  label: 'อนุมัติสมาชิก',      group: 'สมาชิก' },
-  { value: 'member.import',   label: 'Import Excel',       group: 'สมาชิก' },
-  { value: 'member.set_role', label: 'กำหนด Role',         group: 'สมาชิก' },
-  { value: 'seed.view',       label: 'ดูเมล็ดพันธุ์',      group: 'เมล็ดพันธุ์' },
-  { value: 'seed.edit',       label: 'แก้ไขเมล็ดพันธุ์',  group: 'เมล็ดพันธุ์' },
-  { value: 'seed.stock',      label: 'รับ Stock',          group: 'เมล็ดพันธุ์' },
-  { value: 'seed.sales',      label: 'ขายเมล็ด',           group: 'เมล็ดพันธุ์' },
-  { value: 'price.view',      label: 'ดูราคา',             group: 'ราคา' },
-  { value: 'price.edit',      label: 'แก้ไขราคา',          group: 'ราคา' },
-  { value: 'inspection.view', label: 'ดูการตรวจ',          group: 'ตรวจแปลง' },
-  { value: 'inspection.edit', label: 'บันทึกการตรวจ',      group: 'ตรวจแปลง' },
-  { value: 'service.view',    label: 'ดูผู้ให้บริการ',     group: 'บริการ' },
-  { value: 'service.edit',    label: 'แก้ไขผู้ให้บริการ',  group: 'บริการ' },
-  { value: 'report.view',     label: 'ดูรายงาน',           group: 'รายงาน' },
-  { value: 'report.export',   label: 'Export รายงาน',      group: 'รายงาน' },
-  { value: 'system.roles',    label: 'จัดการสิทธิ์',       group: 'ระบบ' },
-  { value: 'system.all',      label: 'ทุกสิทธิ์ (Super)',  group: 'ระบบ' },
-]
-
-async function updateDeptPermissions(profileId: string, dept: Department, perms: Permission[]) {
-  if (!supabase) { console.info('[mock] updateDeptPermissions', profileId, dept); return }
-  const { error } = await supabase
-    .from('profiles')
-    .update({ department: dept, permissions: perms })
-    .eq('id', profileId)
-  if (error) throw new Error(error.message)
-}
+const EMPTY_PERM = { can_view: false, can_create: false, can_update: false, can_approve: false }
 
 export default function AdminRoles() {
-  const [members, setMembers] = useState<AdminMemberRow[]>([])
+  const { user } = useAuth()
+  const [features, setFeatures] = useState<FeatureCatalogRow[]>([])
+  const [roleKey, setRoleKey] = useState('')
+  const [roles, setRoles] = useState<string[]>([])
+  const [matrix, setMatrix] = useState<Record<string, MatrixRow>>({})
   const [loading, setLoading] = useState(true)
-  const [search, setSearch]   = useState('')
-  const [acting, setActing]   = useState<string | null>(null)
-  const [toast, setToast]     = useState<{ ok: boolean; msg: string } | null>(null)
-  const [editDept, setEditDept]   = useState<Record<string, Department>>({})
-  const [editPerms, setEditPerms] = useState<Record<string, Permission[]>>({})
+  const [savingKey, setSavingKey] = useState<string | null>(null)
 
-  const flash = (ok: boolean, msg: string) => {
-    setToast({ ok, msg }); setTimeout(() => setToast(null), 4000)
-  }
+  const isSuperAdmin = user?.role === 'admin' && (user?.permissions?.includes('system.all') || user?.permissions?.includes('system.roles'))
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    try {
-      const data = await fetchAdminMembers()
-      // show only admin-role users
-      const admins = (data as unknown as Record<string, unknown>[]).filter(u => u.role === 'admin')
-      setMembers(admins as unknown as AdminMemberRow[])
-    } catch (e) {
-      flash(false, 'โหลดข้อมูลไม่สำเร็จ')
-    } finally { setLoading(false) }
+  useEffect(() => {
+    ;(async () => {
+      setLoading(true)
+      try {
+        const [f] = await Promise.all([fetchFeatureCatalog()])
+        setFeatures(f)
+        if (supabase) {
+          const { data } = await supabase.from('role_permissions').select('role_key')
+          const keys = [...new Set((data ?? []).map((x: { role_key: string }) => x.role_key))]
+          setRoles(keys)
+          if (!roleKey && keys.length > 0) setRoleKey(keys[0])
+        }
+      } finally {
+        setLoading(false)
+      }
+    })()
   }, [])
 
-  useEffect(() => { load() }, [load])
+  useEffect(() => {
+    if (!roleKey) return
+    ;(async () => {
+      const perms = await fetchRolePermissions(roleKey)
+      const byFeature = new Map(perms.map((p) => [p.feature_key, p]))
+      const next: Record<string, MatrixRow> = {}
+      for (const f of features) {
+        const p = byFeature.get(f.feature_key)
+        next[f.feature_key] = { ...f, ...(p ?? EMPTY_PERM), role_key: roleKey, feature_key: f.feature_key } as MatrixRow
+      }
+      setMatrix(next)
+    })()
+  }, [roleKey, features])
 
-  const getDept = (u: Record<string, unknown>) =>
-    (editDept[String(u.id)] ?? u.department ?? '') as Department | ''
+  const rows = useMemo(() => Object.values(matrix), [matrix])
 
-  const getPerms = (u: Record<string, unknown>): Permission[] => {
-    if (editPerms[String(u.id)]) return editPerms[String(u.id)]
-    try { return (u.permissions as Permission[]) ?? [] }
-    catch { return [] }
-  }
-
-  const setDept = (id: string, dept: Department) => {
-    setEditDept(d => ({ ...d, [id]: dept }))
-    // auto-fill default permissions for that dept
-    setEditPerms(p => ({ ...p, [id]: [...DEPT_PERMISSIONS[dept]] }))
-  }
-
-  const togglePerm = (id: string, perm: Permission, current: Permission[]) => {
-    const next = current.includes(perm)
-      ? current.filter(p => p !== perm)
-      : [...current, perm]
-    setEditPerms(p => ({ ...p, [id]: next }))
-  }
-
-  const handleSave = async (u: Record<string, unknown>) => {
-    const id   = String(u.id)
-    const dept = getDept(u) as Department
-    if (!dept) { flash(false, 'กรุณาเลือกฝ่ายก่อน'); return }
-    const perms = getPerms(u)
-    setActing(id)
+  const toggle = async (featureKey: string, field: keyof typeof EMPTY_PERM) => {
+    if (!isSuperAdmin) return
+    const row = matrix[featureKey]
+    if (!row) return
+    const payload = { ...row, [field]: !row[field] }
+    setMatrix((prev) => ({ ...prev, [featureKey]: payload }))
+    setSavingKey(`${featureKey}:${field}`)
     try {
-      await updateDeptPermissions(id, dept, perms)
-      flash(true, `✅ บันทึกสิทธิ์ ${String(u.full_name)} สำเร็จ${isSupabaseReady ? ' (Supabase)' : ' (Mock)'}`)
-      await load()
-    } catch (e) {
-      flash(false, e instanceof Error ? e.message : 'บันทึกไม่สำเร็จ')
-    } finally { setActing(null) }
+      await upsertRolePermission(roleKey, featureKey, {
+        can_view: payload.can_view,
+        can_create: payload.can_create,
+        can_update: payload.can_update,
+        can_approve: payload.can_approve,
+      })
+    } finally {
+      setSavingKey(null)
+    }
   }
-
-  const rows = (members as unknown as Record<string, unknown>[])
-    .filter(u => String(u.full_name ?? '').includes(search) || String(u.id_card ?? '').includes(search))
-
-  // group permissions by group
-  const groups = [...new Set(ALL_PERMS.map(p => p.group))]
 
   return (
-    <div className="max-w-4xl mx-auto space-y-5">
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <div>
-          <h1 className="text-xl font-bold text-gray-900">กำหนดสิทธิ์ / Role / Department</h1>
-          <div className="flex items-center gap-1.5 mt-0.5 text-sm">
-            {isSupabaseReady
-              ? <><Wifi className="w-3.5 h-3.5 text-emerald-600"/><span className="text-emerald-600">Supabase</span></>
-              : <><WifiOff className="w-3.5 h-3.5 text-amber-500"/><span className="text-amber-600">Mock</span></>}
-          </div>
-        </div>
-        <button onClick={()=>{setLoading(true);load()}}
-          className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-200 rounded-xl text-sm hover:bg-gray-50 shadow-sm">
-          <RefreshCw className="w-4 h-4"/>รีโหลด
-        </button>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Role Permissions Matrix</h1>
+        <button onClick={() => window.location.reload()} className="px-3 py-2 border rounded-lg text-sm flex items-center gap-2"><RefreshCw className="w-4 h-4"/>Reload</button>
       </div>
 
-      {toast && (
-        <div className={`rounded-xl px-4 py-3 flex items-center gap-2 text-sm font-medium border
-          ${toast.ok ? 'bg-emerald-50 border-emerald-300 text-emerald-700' : 'bg-red-50 border-red-300 text-red-700'}`}>
-          {toast.ok ? <Check className="w-4 h-4"/> : <AlertCircle className="w-4 h-4"/>}
-          {toast.msg}
-          <button onClick={()=>setToast(null)} className="ml-auto opacity-60 text-lg leading-none">×</button>
-        </div>
-      )}
+      <div className="bg-white border rounded-xl p-3">
+        <label className="text-sm font-medium">Role Key</label>
+        <select className="w-full mt-1 border rounded-lg p-2" value={roleKey} onChange={(e) => setRoleKey(e.target.value)}>
+          {roles.map((r) => <option key={r} value={r}>{r}</option>)}
+        </select>
+      </div>
 
-      {/* SQL reminder */}
-      {!isSupabaseReady && (
-        <div className="bg-amber-50 border-2 border-amber-300 rounded-2xl p-4">
-          <p className="font-bold text-amber-800 text-sm mb-1">⚠️ ต้องรัน SQL migration ก่อน</p>
-          <p className="text-amber-700 text-xs">รัน <code className="bg-white px-1 rounded">supabase/migrations/add_department_permissions.sql</code> ใน Supabase SQL Editor</p>
-        </div>
-      )}
-
-      <input value={search} onChange={e=>setSearch(e.target.value)}
-        placeholder="ค้นหาชื่อ หรือเลขบัตร..."
-        className="w-full border-2 border-gray-200 rounded-xl px-4 py-2.5 text-sm focus:outline-none focus:border-emerald-500"/>
-
-      {loading ? (
-        <div className="flex justify-center py-12"><RefreshCw className="w-6 h-6 text-emerald-600 animate-spin"/></div>
-      ) : rows.length === 0 ? (
-        <div className="text-center py-12 text-gray-400">
-          <div className="text-4xl mb-3">🔐</div>
-          <p className="font-medium">ไม่มีผู้ใช้ role admin</p>
-          <p className="text-xs mt-1">ตั้ง role = admin ในหน้า สมาชิก ก่อน</p>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {rows.map(u => {
-            const id    = String(u.id)
-            const dept  = getDept(u)
-            const perms = getPerms(u)
-            const isA   = acting === id
-
-            return (
-              <div key={id} className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-                {/* User header */}
-                <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100">
-                  <div className="w-10 h-10 rounded-full bg-purple-100 text-purple-700 font-bold flex items-center justify-center flex-shrink-0">
-                    {String(u.full_name ?? '?').charAt(0)}
-                  </div>
-                  <div>
-                    <div className="font-bold text-gray-900">{String(u.full_name ?? '-')}</div>
-                    <div className="text-xs text-gray-400">{String(u.id_card ?? '')} • role: {String(u.role ?? '')}</div>
-                  </div>
-                  <div className="ml-auto">
-                    {dept && (
-                      <span className="text-xs bg-purple-100 text-purple-700 px-3 py-1 rounded-full font-semibold">
-                        {DEPARTMENTS.find(d=>d.value===dept)?.icon} {DEPARTMENTS.find(d=>d.value===dept)?.label}
-                      </span>
-                    )}
-                  </div>
-                </div>
-
-                <div className="p-5 space-y-4">
-                  {/* Department picker */}
-                  <div>
-                    <label className="text-xs font-bold text-gray-500 uppercase tracking-wide block mb-2">ฝ่าย (Department)</label>
-                    <div className="flex flex-wrap gap-2">
-                      {DEPARTMENTS.map(d => (
-                        <button key={d.value} onClick={()=>setDept(id, d.value)}
-                          className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-semibold border-2 transition-all
-                            ${dept===d.value
-                              ? 'bg-purple-600 border-purple-600 text-white shadow-sm'
-                              : 'bg-white border-gray-200 text-gray-600 hover:border-purple-300'}`}>
-                          <span>{d.icon}</span>{d.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Permission checkboxes grouped */}
-                  <div>
-                    <label className="text-xs font-bold text-gray-500 uppercase tracking-wide block mb-2">สิทธิ์ (Permissions)</label>
-                    <div className="space-y-3">
-                      {groups.map(group => (
-                        <div key={group}>
-                          <div className="text-xs text-gray-400 font-semibold mb-1.5">{group}</div>
-                          <div className="flex flex-wrap gap-2">
-                            {ALL_PERMS.filter(p=>p.group===group).map(p => (
-                              <button key={p.value}
-                                onClick={()=>togglePerm(id, p.value, perms)}
-                                className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold border transition-all
-                                  ${perms.includes(p.value)
-                                    ? 'bg-emerald-600 border-emerald-600 text-white'
-                                    : 'bg-white border-gray-200 text-gray-500 hover:border-emerald-300'}`}>
-                                {perms.includes(p.value) && <Check className="w-3 h-3"/>}
-                                {p.label}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Save */}
-                  <button onClick={()=>handleSave(u)} disabled={isA || !dept}
-                    className={`w-full py-3 rounded-xl font-bold text-sm flex items-center justify-center gap-2 transition-all
-                      ${!dept ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                      : isA ? 'bg-emerald-100 text-emerald-400 cursor-wait'
-                      : 'bg-emerald-600 text-white hover:bg-emerald-700 active:scale-[.98]'}`}>
-                    {isA ? <><RefreshCw className="w-4 h-4 animate-spin"/>กำลังบันทึก...</> : <><Check className="w-4 h-4"/>บันทึกสิทธิ์</>}
-                  </button>
-                </div>
-              </div>
-            )
-          })}
+      {loading ? <div className="py-10 text-center"><RefreshCw className="w-5 h-5 animate-spin inline-block"/></div> : (
+        <div className="overflow-auto bg-white border rounded-xl">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left">feature_name</th><th className="px-3 py-2 text-left">group_name</th><th className="px-3 py-2 text-left">app_area</th>
+                <th className="px-3 py-2">can_view</th><th className="px-3 py-2">can_create</th><th className="px-3 py-2">can_update</th><th className="px-3 py-2">can_approve</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.feature_key} className="border-t">
+                  <td className="px-3 py-2">{r.feature_name}</td><td className="px-3 py-2">{r.group_name}</td><td className="px-3 py-2">{r.app_area}</td>
+                  {(['can_view', 'can_create', 'can_update', 'can_approve'] as const).map((f) => (
+                    <td key={f} className="px-3 py-2 text-center">
+                      <button disabled={!isSuperAdmin} onClick={() => toggle(r.feature_key, f)} className={`w-7 h-7 rounded border inline-flex items-center justify-center ${r[f] ? 'bg-emerald-600 text-white border-emerald-600' : 'bg-white text-gray-400'} ${!isSuperAdmin ? 'opacity-50 cursor-not-allowed' : ''}`}>
+                        {savingKey === `${r.feature_key}:${f}` ? <RefreshCw className="w-3 h-3 animate-spin"/> : r[f] ? <Check className="w-3 h-3"/> : null}
+                      </button>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       )}
     </div>

--- a/src/app/admin/AdminSeedSales.tsx
+++ b/src/app/admin/AdminSeedSales.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 
-type Farmer = { id: string; name: string }
+type Farmer = { id: string; name: string; phone: string; national_id: string }
 
 type SeedStockLot = {
   id: string
@@ -58,9 +58,9 @@ const STOCK_STORAGE_KEY = 'kfarm_seed_stock_lots_v1'
 const SALES_STORAGE_KEY = 'kfarm_seed_sales_v1'
 
 const FARMERS: Farmer[] = [
-  { id: 'f-001', name: 'สมชาย ใจดี' },
-  { id: 'f-002', name: 'มาลัย พูนสุข' },
-  { id: 'f-003', name: 'ประยูร นครชัย' },
+  { id: 'f-001', name: 'สมชาย ใจดี', phone: '0812345678', national_id: '1100100123456' },
+  { id: 'f-002', name: 'มาลัย พูนสุข', phone: '0898765432', national_id: '1100100654321' },
+  { id: 'f-003', name: 'ประยูร นครชัย', phone: '0861112233', national_id: '1100100998877' },
 ]
 
 function loadLots(): SeedStockLot[] {
@@ -85,6 +85,16 @@ function loadSales(): SeedSale[] {
   }
 }
 
+function fetchSeedSuppliers(lots: SeedStockLot[]) {
+  return Array.from(new Map(lots.map((lot) => [lot.supplier_id, { id: lot.supplier_id, name: lot.supplier_name }])).values())
+}
+
+function fetchSeedVarietiesBySupplier(lots: SeedStockLot[], supplierId: string) {
+  return Array.from(new Map(lots
+    .filter((lot) => !supplierId || lot.supplier_id === supplierId)
+    .map((lot) => [lot.variety_id, { id: lot.variety_id, name: lot.variety_name }])).values())
+}
+
 export default function AdminSeedSales() {
   const [lots, setLots] = useState<SeedStockLot[]>(() => loadLots())
   const [sales, setSales] = useState<SeedSale[]>(() => loadSales())
@@ -97,18 +107,8 @@ export default function AdminSeedSales() {
 
   const availableLots = useMemo(() => lots.filter((lot) => lot.quantity_balance > 0), [lots])
   const selectedLot = useMemo(() => availableLots.find((lot) => lot.id === form.lot_id), [availableLots, form.lot_id])
-
-  const suppliers = useMemo(
-    () => Array.from(new Map(availableLots.map((lot) => [lot.supplier_id, { id: lot.supplier_id, name: lot.supplier_name }])).values()),
-    [availableLots]
-  )
-
-  const varieties = useMemo(
-    () => Array.from(new Map(availableLots
-      .filter((lot) => !form.supplier_id || lot.supplier_id === form.supplier_id)
-      .map((lot) => [lot.variety_id, { id: lot.variety_id, name: lot.variety_name }])).values()),
-    [availableLots, form.supplier_id]
-  )
+  const suppliers = useMemo(() => fetchSeedSuppliers(availableLots), [availableLots])
+  const varieties = useMemo(() => fetchSeedVarietiesBySupplier(availableLots, form.supplier_id), [availableLots, form.supplier_id])
 
   const filteredLots = useMemo(
     () => availableLots.filter((lot) =>
@@ -117,10 +117,15 @@ export default function AdminSeedSales() {
     [availableLots, form.supplier_id, form.variety_id]
   )
 
-  const farmerOptions = useMemo(
-    () => FARMERS.filter((f) => f.name.toLowerCase().includes(farmerSearch.toLowerCase())),
-    [farmerSearch]
-  )
+  const farmerOptions = useMemo(() => {
+    const keyword = farmerSearch.trim().toLowerCase()
+    if (!keyword) return FARMERS
+    return FARMERS.filter((f) =>
+      f.name.toLowerCase().includes(keyword)
+      || f.phone.includes(keyword)
+      || f.national_id.includes(keyword)
+    )
+  }, [farmerSearch])
 
   const quantity = Number(form.quantity || 0)
   const bagWeight = Number(form.bag_weight_kg || 0)
@@ -157,7 +162,7 @@ export default function AdminSeedSales() {
     }
 
     if (quantity > lot.quantity_balance) {
-      setError('จำนวนเกิน stock')
+      setError('จำนวนขายมากกว่ายอดคงเหลือ')
       return
     }
 
@@ -183,11 +188,11 @@ export default function AdminSeedSales() {
 
     const nextLots = lots.map((item) => {
       if (item.id !== lot.id) return item
-      const nextBalance = item.quantity_balance - quantity
+      const newBalance = item.quantity_balance - quantity
       return {
         ...item,
-        quantity_balance: nextBalance,
-        status: nextBalance === 0 ? 'sold_out' as const : 'active' as const,
+        quantity_balance: newBalance,
+        status: newBalance === 0 ? 'sold_out' as const : 'active' as const,
       }
     })
 
@@ -215,10 +220,10 @@ export default function AdminSeedSales() {
       </div>
 
       <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
-        <input placeholder="ค้นหาเกษตรกร" value={farmerSearch} onChange={(e) => setFarmerSearch(e.target.value)} className="border rounded-lg p-2" />
+        <input placeholder="ค้นหาเกษตรกร (ชื่อ / เบอร์ / บัตร)" value={farmerSearch} onChange={(e) => setFarmerSearch(e.target.value)} className="border rounded-lg p-2" />
         <select required value={form.farmer_id} onChange={(e) => setForm((p) => ({ ...p, farmer_id: e.target.value }))} className="border rounded-lg p-2">
           <option value="">เลือกเกษตรกร</option>
-          {farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name}</option>)}
+          {farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name} | {f.phone}</option>)}
         </select>
         <select value={form.supplier_id} onChange={(e) => setForm((p) => ({ ...p, supplier_id: e.target.value, variety_id: '', lot_id: '' }))} className="border rounded-lg p-2">
           <option value="">เลือก Supplier</option>
@@ -252,23 +257,23 @@ export default function AdminSeedSales() {
 
         {selectedLot && (
           <div className="md:col-span-3 bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-sm grid grid-cols-2 md:grid-cols-4 gap-2">
+            <div>Lot: <b>{selectedLot.lot_no}</b></div>
             <div>คงเหลือ: <b>{selectedLot.quantity_balance}</b> ถุง</div>
             <div>kg/ถุง: <b>{selectedLot.bag_weight_kg}</b></div>
-            <div>ราคาขาย: <b>{selectedLot.sell_price_per_bag}</b></div>
-            <div>วันหมดอายุ: <b>{selectedLot.expiry_date}</b></div>
+            <div>ราคา: <b>{selectedLot.sell_price_per_bag}</b></div>
           </div>
         )}
 
         {error && <div className="md:col-span-3 text-red-600 text-sm font-semibold">{error}</div>}
 
-        <button disabled={overStock} type="submit" className="md:col-span-3 bg-green-600 disabled:bg-gray-400 text-white rounded-lg py-2 font-semibold">บันทึกการขาย</button>
+        <button disabled={overStock} type="submit" className="md:col-span-3 bg-green-600 disabled:bg-gray-400 text-white rounded-lg py-2 font-semibold">ขายเมล็ด</button>
       </form>
 
       <div className="bg-white rounded-2xl border border-gray-200 overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead className="bg-gray-50">
             <tr>
-              {['วันที่', 'เกษตรกร', 'พันธุ์', 'Lot', 'จำนวน', 'kg', 'ราคา/ถุง', 'ยอดรวม', 'สถานะ'].map((h) => (
+              {['วันที่', 'เกษตรกร', 'พันธุ์', 'Lot', 'จำนวน', 'ราคา', 'ยอดรวม'].map((h) => (
                 <th key={h} className="text-left p-3 font-semibold text-gray-700">{h}</th>
               ))}
             </tr>
@@ -281,14 +286,12 @@ export default function AdminSeedSales() {
                 <td className="p-3">{sale.variety_name}</td>
                 <td className="p-3">{sale.lot_no}</td>
                 <td className="p-3">{sale.quantity}</td>
-                <td className="p-3">{sale.total_weight_kg}</td>
                 <td className="p-3">{sale.sell_price_per_bag}</td>
                 <td className="p-3">{sale.total_amount}</td>
-                <td className="p-3">{sale.payment_status}</td>
               </tr>
             ))}
             {sales.length === 0 && (
-              <tr><td className="p-4 text-gray-500" colSpan={9}>ยังไม่มีข้อมูลการขาย</td></tr>
+              <tr><td className="p-4 text-gray-500" colSpan={7}>ยังไม่มีข้อมูลการขาย</td></tr>
             )}
           </tbody>
         </table>

--- a/src/app/admin/AdminSeedSales.tsx
+++ b/src/app/admin/AdminSeedSales.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { requireSupabase } from '../../lib/supabase'
 
 type Farmer = { id: string; name: string; phone: string; national_id: string }
 
@@ -12,14 +13,8 @@ type SeedStockLot = {
   quantity_in: number
   quantity_balance: number
   bag_weight_kg: number
-  cost_price_per_bag: number
   sell_price_per_bag: number
-  total_weight_kg: number
-  total_cost: number
-  received_date: string
-  expiry_date: string
   created_at: string
-  status?: 'active' | 'sold_out'
 }
 
 type SeedSale = {
@@ -27,275 +22,148 @@ type SeedSale = {
   sale_date: string
   farmer_id: string
   farmer_name: string
-  supplier_id: string
   supplier_name: string
-  variety_id: string
   variety_name: string
-  lot_id: string
   lot_no: string
   quantity: number
-  bag_weight_kg: number
   sell_price_per_bag: number
-  total_weight_kg: number
   total_amount: number
-  payment_status: 'unpaid' | 'partial' | 'paid'
-  created_at: string
+}
+
+type Reservation = {
+  id: string
+  farmer_id: string
+  farmer_name: string
+  lot_id: string
+  lot_no: string
+  variety_name: string
+  reserved_qty: number
 }
 
 type FormState = {
-  farmer_id: string
-  supplier_id: string
-  variety_id: string
-  lot_id: string
-  quantity: string
-  bag_weight_kg: string
-  sell_price_per_bag: string
-  sale_date: string
-  payment_status: 'unpaid' | 'partial' | 'paid'
-}
-
-const STOCK_STORAGE_KEY = 'kfarm_seed_stock_lots_v1'
-const SALES_STORAGE_KEY = 'kfarm_seed_sales_v1'
-
-const FARMERS: Farmer[] = [
-  { id: 'f-001', name: 'สมชาย ใจดี', phone: '0812345678', national_id: '1100100123456' },
-  { id: 'f-002', name: 'มาลัย พูนสุข', phone: '0898765432', national_id: '1100100654321' },
-  { id: 'f-003', name: 'ประยูร นครชัย', phone: '0861112233', national_id: '1100100998877' },
-]
-
-function loadLots(): SeedStockLot[] {
-  try {
-    const raw = localStorage.getItem(STOCK_STORAGE_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-function loadSales(): SeedSale[] {
-  try {
-    const raw = localStorage.getItem(SALES_STORAGE_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
-
-function fetchSeedSuppliers(lots: SeedStockLot[]) {
-  return Array.from(new Map(lots.map((lot) => [lot.supplier_id, { id: lot.supplier_id, name: lot.supplier_name }])).values())
-}
-
-function fetchSeedVarietiesBySupplier(lots: SeedStockLot[], supplierId: string) {
-  return Array.from(new Map(lots
-    .filter((lot) => !supplierId || lot.supplier_id === supplierId)
-    .map((lot) => [lot.variety_id, { id: lot.variety_id, name: lot.variety_name }])).values())
+  farmer_id: string; supplier_id: string; variety_id: string; lot_id: string; quantity: string
+  bag_weight_kg: string; sell_price_per_bag: string; sale_date: string; payment_status: 'unpaid' | 'partial' | 'paid'
+  reservation_id: string
 }
 
 export default function AdminSeedSales() {
-  const [lots, setLots] = useState<SeedStockLot[]>(() => loadLots())
-  const [sales, setSales] = useState<SeedSale[]>(() => loadSales())
+  const [lots, setLots] = useState<SeedStockLot[]>([])
+  const [sales, setSales] = useState<SeedSale[]>([])
+  const [farmers, setFarmers] = useState<Farmer[]>([])
+  const [reservations, setReservations] = useState<Reservation[]>([])
   const [farmerSearch, setFarmerSearch] = useState('')
   const [error, setError] = useState('')
-  const [form, setForm] = useState<FormState>({
-    farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '',
-    sell_price_per_bag: '', sale_date: new Date().toISOString().slice(0, 10), payment_status: 'unpaid',
-  })
+  const [ok, setOk] = useState('')
+  const [form, setForm] = useState<FormState>({ farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '', sell_price_per_bag: '', sale_date: new Date().toISOString().slice(0, 10), payment_status: 'unpaid', reservation_id: '' })
+
+  const loadData = async () => {
+    const db = requireSupabase()
+    const [supRes, varRes, lotRes, salesRes, farmerRes, reserveRes] = await Promise.all([
+      db.from('seed_suppliers').select('id,supplier_name'),
+      db.from('seed_varieties').select('id,variety_name'),
+      db.from('seed_stock_lots').select('id,supplier_id,variety_id,lot_no,quantity_in,quantity_balance,bag_weight_kg,sell_price_per_bag,created_at').gt('quantity_balance', 0),
+      db.from('seed_sales').select('*').order('created_at', { ascending: false }),
+      db.from('profiles').select('id,full_name,phone').eq('role', 'farmer').order('full_name'),
+      db.from('seed_sale_reservations').select('*').in('status', ['approved', 'reserved']).order('created_at', { ascending: false }),
+    ])
+
+    if (supRes.error || varRes.error || lotRes.error || salesRes.error || farmerRes.error) {
+      throw new Error([supRes.error?.message, varRes.error?.message, lotRes.error?.message, salesRes.error?.message, farmerRes.error?.message].filter(Boolean).join(' | '))
+    }
+
+    const supplierMap = new Map((supRes.data ?? []).map((s: {id:string,supplier_name:string}) => [s.id, s.supplier_name]))
+    const varietyMap = new Map((varRes.data ?? []).map((v: {id:string,variety_name:string}) => [v.id, v.variety_name]))
+    const farmerMap = new Map((farmerRes.data ?? []).map((f: {id:string,full_name:string}) => [f.id, f.full_name]))
+
+    const lotRows = (lotRes.data ?? []) as Array<Record<string, unknown>>
+    setLots(lotRows.map((r) => ({
+      id: String(r.id), supplier_id: String(r.supplier_id), variety_id: String(r.variety_id), lot_no: String(r.lot_no),
+      quantity_in: Number(r.quantity_in ?? 0), quantity_balance: Number(r.quantity_balance ?? 0), bag_weight_kg: Number(r.bag_weight_kg ?? 0), sell_price_per_bag: Number(r.sell_price_per_bag ?? 0), created_at: String(r.created_at ?? ''),
+      supplier_name: supplierMap.get(String(r.supplier_id)) ?? '-', variety_name: varietyMap.get(String(r.variety_id)) ?? '-',
+    })))
+
+    const salesRows = (salesRes.data ?? []) as Array<Record<string, unknown>>
+    setSales(salesRows.map((r) => ({
+      id: String(r.id), sale_date: String(r.sale_date ?? ''), farmer_id: String(r.farmer_id ?? ''), farmer_name: farmerMap.get(String(r.farmer_id ?? '')) ?? '-', supplier_name: supplierMap.get(String(r.supplier_id ?? '')) ?? '-', variety_name: varietyMap.get(String(r.variety_id ?? '')) ?? '-', lot_no: String(r.lot_no ?? ''), quantity: Number(r.quantity ?? 0), sell_price_per_bag: Number(r.sell_price_per_bag ?? 0), total_amount: Number(r.total_amount ?? 0),
+    })))
+
+    setFarmers((farmerRes.data ?? []).map((f: {id:string,full_name:string,phone:string|null}) => ({ id: f.id, name: f.full_name, phone: f.phone ?? '', national_id: '' })))
+
+    if (!reserveRes.error) {
+      const rs = (reserveRes.data ?? []) as Array<Record<string, unknown>>
+      setReservations(rs.map((r) => ({ id: String(r.id), farmer_id: String(r.farmer_id ?? ''), farmer_name: farmerMap.get(String(r.farmer_id ?? '')) ?? '-', lot_id: String(r.lot_id ?? ''), lot_no: String(r.lot_no ?? ''), variety_name: String(r.variety_name ?? ''), reserved_qty: Number(r.quantity ?? 0) })))
+    }
+  }
+
+  useEffect(() => { void loadData().catch((e: unknown) => setError(e instanceof Error ? e.message : 'โหลดข้อมูลไม่สำเร็จ')) }, [])
 
   const availableLots = useMemo(() => lots.filter((lot) => lot.quantity_balance > 0), [lots])
   const selectedLot = useMemo(() => availableLots.find((lot) => lot.id === form.lot_id), [availableLots, form.lot_id])
-  const suppliers = useMemo(() => fetchSeedSuppliers(availableLots), [availableLots])
-  const varieties = useMemo(() => fetchSeedVarietiesBySupplier(availableLots, form.supplier_id), [availableLots, form.supplier_id])
-
-  const filteredLots = useMemo(
-    () => availableLots.filter((lot) =>
-      (!form.supplier_id || lot.supplier_id === form.supplier_id)
-      && (!form.variety_id || lot.variety_id === form.variety_id)),
-    [availableLots, form.supplier_id, form.variety_id]
-  )
-
-  const farmerOptions = useMemo(() => {
-    const keyword = farmerSearch.trim().toLowerCase()
-    if (!keyword) return FARMERS
-    return FARMERS.filter((f) =>
-      f.name.toLowerCase().includes(keyword)
-      || f.phone.includes(keyword)
-      || f.national_id.includes(keyword)
-    )
-  }, [farmerSearch])
+  const suppliers = useMemo(() => Array.from(new Map(availableLots.map((l) => [l.supplier_id, { id: l.supplier_id, name: l.supplier_name }])).values()), [availableLots])
+  const varieties = useMemo(() => Array.from(new Map(availableLots.filter(l => !form.supplier_id || l.supplier_id === form.supplier_id).map((l) => [l.variety_id, { id: l.variety_id, name: l.variety_name }])).values()), [availableLots, form.supplier_id])
+  const filteredLots = useMemo(() => availableLots.filter((lot) => (!form.supplier_id || lot.supplier_id === form.supplier_id) && (!form.variety_id || lot.variety_id === form.variety_id)), [availableLots, form.supplier_id, form.variety_id])
+  const farmerOptions = useMemo(() => { const keyword = farmerSearch.trim().toLowerCase(); if (!keyword) return farmers; return farmers.filter((f) => f.name.toLowerCase().includes(keyword) || f.phone.includes(keyword) || f.national_id.includes(keyword)) }, [farmerSearch, farmers])
 
   const quantity = Number(form.quantity || 0)
-  const bagWeight = Number(form.bag_weight_kg || 0)
-  const sellPrice = Number(form.sell_price_per_bag || 0)
-  const totalWeight = quantity * bagWeight
-  const totalAmount = quantity * sellPrice
+  const totalAmount = quantity * Number(form.sell_price_per_bag || 0)
   const remaining = selectedLot ? selectedLot.quantity_balance - quantity : 0
   const overStock = !!selectedLot && quantity > selectedLot.quantity_balance
 
+  const applyReservation = (reservationId: string) => {
+    const r = reservations.find(x => x.id === reservationId)
+    if (!r) return
+    const lot = availableLots.find(x => x.id === r.lot_id)
+    setForm((p) => ({ ...p, reservation_id: reservationId, farmer_id: r.farmer_id, lot_id: r.lot_id, quantity: String(r.reserved_qty), supplier_id: lot?.supplier_id ?? p.supplier_id, variety_id: lot?.variety_id ?? p.variety_id, bag_weight_kg: lot ? String(lot.bag_weight_kg) : p.bag_weight_kg, sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : p.sell_price_per_bag }))
+  }
+
   const onLotChange = (lotId: string) => {
     const lot = availableLots.find((item) => item.id === lotId)
-    setForm((prev) => ({
-      ...prev,
-      lot_id: lotId,
-      supplier_id: lot?.supplier_id ?? prev.supplier_id,
-      variety_id: lot?.variety_id ?? prev.variety_id,
-      bag_weight_kg: lot ? String(lot.bag_weight_kg) : '',
-      sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : '',
-    }))
+    setForm((prev) => ({ ...prev, lot_id: lotId, supplier_id: lot?.supplier_id ?? prev.supplier_id, variety_id: lot?.variety_id ?? prev.variety_id, bag_weight_kg: lot ? String(lot.bag_weight_kg) : '', sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : '' }))
     setError('')
   }
 
-  const onSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    setError('')
-
-    const lot = lots.find((item) => item.id === form.lot_id)
-    const farmer = FARMERS.find((item) => item.id === form.farmer_id)
-    if (!lot || !farmer) return
-
-    if (quantity <= 0) {
-      setError('จำนวนถุงต้องมากกว่า 0')
-      return
-    }
-
-    if (quantity > lot.quantity_balance) {
-      setError('จำนวนขายมากกว่ายอดคงเหลือ')
-      return
-    }
-
-    const sale: SeedSale = {
-      id: `sale-${Date.now()}`,
-      sale_date: form.sale_date,
-      farmer_id: farmer.id,
-      farmer_name: farmer.name,
-      supplier_id: lot.supplier_id,
-      supplier_name: lot.supplier_name,
-      variety_id: lot.variety_id,
-      variety_name: lot.variety_name,
-      lot_id: lot.id,
-      lot_no: lot.lot_no,
-      quantity,
-      bag_weight_kg: Number(form.bag_weight_kg),
-      sell_price_per_bag: Number(form.sell_price_per_bag),
-      total_weight_kg: quantity * Number(form.bag_weight_kg),
-      total_amount: quantity * Number(form.sell_price_per_bag),
-      payment_status: form.payment_status,
-      created_at: new Date().toISOString(),
-    }
-
-    const nextLots = lots.map((item) => {
-      if (item.id !== lot.id) return item
-      const newBalance = item.quantity_balance - quantity
-      return {
-        ...item,
-        quantity_balance: newBalance,
-        status: newBalance === 0 ? 'sold_out' as const : 'active' as const,
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault(); setError(''); setOk('')
+    try {
+      if (!selectedLot) throw new Error('กรุณาเลือก Lot')
+      if (!form.farmer_id) throw new Error('กรุณาเลือกเกษตรกร')
+      if (quantity <= 0) throw new Error('จำนวนถุงต้องมากกว่า 0')
+      if (quantity > selectedLot.quantity_balance) throw new Error('จำนวนขายมากกว่ายอดคงเหลือ')
+      const db = requireSupabase()
+      const salePayload = { sale_date: form.sale_date, farmer_id: form.farmer_id, supplier_id: selectedLot.supplier_id, variety_id: selectedLot.variety_id, lot_id: selectedLot.id, lot_no: selectedLot.lot_no, quantity, bag_weight_kg: Number(form.bag_weight_kg), sell_price_per_bag: Number(form.sell_price_per_bag), total_weight_kg: quantity * Number(form.bag_weight_kg), total_amount: quantity * Number(form.sell_price_per_bag), payment_status: form.payment_status }
+      const { error: saleErr } = await db.from('seed_sales').insert(salePayload)
+      if (saleErr) throw new Error(`บันทึกขายไม่สำเร็จ: ${saleErr.message}`)
+      const { error: stockErr } = await db.from('seed_stock_lots').update({ quantity_balance: selectedLot.quantity_balance - quantity, status: selectedLot.quantity_balance - quantity <= 0 ? 'sold_out' : 'available' }).eq('id', selectedLot.id)
+      if (stockErr) throw new Error(`อัปเดตสต็อกไม่สำเร็จ: ${stockErr.message}`)
+      if (form.reservation_id) {
+        await db.from('seed_sale_reservations').update({ status: 'sold' }).eq('id', form.reservation_id)
       }
-    })
-
-    const nextSales = [sale, ...sales]
-    setLots(nextLots)
-    setSales(nextSales)
-    localStorage.setItem(STOCK_STORAGE_KEY, JSON.stringify(nextLots))
-    localStorage.setItem(SALES_STORAGE_KEY, JSON.stringify(nextSales))
-
-    setForm((prev) => ({
-      ...prev,
-      lot_id: '',
-      quantity: '',
-      bag_weight_kg: '',
-      sell_price_per_bag: '',
-      supplier_id: '',
-      variety_id: '',
-    }))
+      setOk('บันทึกการขายสำเร็จ')
+      setForm((p) => ({ ...p, farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '', sell_price_per_bag: '', reservation_id: '' }))
+      await loadData()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'บันทึกขายไม่สำเร็จ')
+    }
   }
 
-  return (
-    <div className="max-w-6xl mx-auto space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">ขายเมล็ดพันธุ์ (ตาม Lot)</h1>
-      </div>
-
-      <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
-        <input placeholder="ค้นหาเกษตรกร (ชื่อ / เบอร์ / บัตร)" value={farmerSearch} onChange={(e) => setFarmerSearch(e.target.value)} className="border rounded-lg p-2" />
-        <select required value={form.farmer_id} onChange={(e) => setForm((p) => ({ ...p, farmer_id: e.target.value }))} className="border rounded-lg p-2">
-          <option value="">เลือกเกษตรกร</option>
-          {farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name} | {f.phone}</option>)}
-        </select>
-        <select value={form.supplier_id} onChange={(e) => setForm((p) => ({ ...p, supplier_id: e.target.value, variety_id: '', lot_id: '' }))} className="border rounded-lg p-2">
-          <option value="">เลือก Supplier</option>
-          {suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
-        </select>
-
-        <select value={form.variety_id} onChange={(e) => setForm((p) => ({ ...p, variety_id: e.target.value, lot_id: '' }))} className="border rounded-lg p-2">
-          <option value="">เลือก Variety</option>
-          {varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}
-        </select>
-        <select required value={form.lot_id} onChange={(e) => onLotChange(e.target.value)} className="border rounded-lg p-2">
-          <option value="">เลือก Lot (เหลือ &gt; 0)</option>
-          {filteredLots.map((lot) => <option key={lot.id} value={lot.id}>{lot.lot_no} (คงเหลือ {lot.quantity_balance})</option>)}
-        </select>
-        <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity} onChange={(e) => setForm((p) => ({ ...p, quantity: e.target.value }))} className="border rounded-lg p-2" />
-
-        <input required type="number" min="0" step="0.01" placeholder="kg/ถุง" value={form.bag_weight_kg} onChange={(e) => setForm((p) => ({ ...p, bag_weight_kg: e.target.value }))} className="border rounded-lg p-2" />
-        <input required type="number" min="0" step="0.01" placeholder="ราคาขาย/ถุง" value={form.sell_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, sell_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
-        <input required type="date" value={form.sale_date} onChange={(e) => setForm((p) => ({ ...p, sale_date: e.target.value }))} className="border rounded-lg p-2" />
-
-        <select value={form.payment_status} onChange={(e) => setForm((p) => ({ ...p, payment_status: e.target.value as FormState['payment_status'] }))} className="border rounded-lg p-2">
-          <option value="unpaid">ยังไม่ชำระ</option>
-          <option value="partial">ชำระบางส่วน</option>
-          <option value="paid">ชำระครบ</option>
-        </select>
-        <div className="md:col-span-2 bg-gray-50 rounded-lg p-3 text-sm space-y-1">
-          <div>น้ำหนักรวม: <b>{totalWeight.toLocaleString()} kg</b></div>
-          <div>ยอดขายรวม: <b>{totalAmount.toLocaleString()} บาท</b></div>
-          <div>คงเหลือหลังขาย: <b className={overStock ? 'text-red-600' : ''}>{selectedLot ? remaining.toLocaleString() : '-'} ถุง</b></div>
-        </div>
-
-        {selectedLot && (
-          <div className="md:col-span-3 bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-sm grid grid-cols-2 md:grid-cols-4 gap-2">
-            <div>Lot: <b>{selectedLot.lot_no}</b></div>
-            <div>คงเหลือ: <b>{selectedLot.quantity_balance}</b> ถุง</div>
-            <div>kg/ถุง: <b>{selectedLot.bag_weight_kg}</b></div>
-            <div>ราคา: <b>{selectedLot.sell_price_per_bag}</b></div>
-          </div>
-        )}
-
-        {error && <div className="md:col-span-3 text-red-600 text-sm font-semibold">{error}</div>}
-
-        <button disabled={overStock} type="submit" className="md:col-span-3 bg-green-600 disabled:bg-gray-400 text-white rounded-lg py-2 font-semibold">ขายเมล็ด</button>
-      </form>
-
-      <div className="bg-white rounded-2xl border border-gray-200 overflow-x-auto">
-        <table className="min-w-full text-sm">
-          <thead className="bg-gray-50">
-            <tr>
-              {['วันที่', 'เกษตรกร', 'พันธุ์', 'Lot', 'จำนวน', 'ราคา', 'ยอดรวม'].map((h) => (
-                <th key={h} className="text-left p-3 font-semibold text-gray-700">{h}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {sales.map((sale) => (
-              <tr key={sale.id} className="border-t">
-                <td className="p-3">{sale.sale_date}</td>
-                <td className="p-3">{sale.farmer_name}</td>
-                <td className="p-3">{sale.variety_name}</td>
-                <td className="p-3">{sale.lot_no}</td>
-                <td className="p-3">{sale.quantity}</td>
-                <td className="p-3">{sale.sell_price_per_bag}</td>
-                <td className="p-3">{sale.total_amount}</td>
-              </tr>
-            ))}
-            {sales.length === 0 && (
-              <tr><td className="p-4 text-gray-500" colSpan={7}>ยังไม่มีข้อมูลการขาย</td></tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  )
+  return <div className="max-w-6xl mx-auto space-y-6">{/* UI unchanged mostly */}
+    <div><h1 className="text-2xl font-bold text-gray-900">ขายเมล็ดพันธุ์ (ตาม Lot)</h1></div>
+    {ok && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-emerald-700 text-sm">{ok}</div>}
+    {error && <div className="bg-red-50 border border-red-300 p-2 rounded text-red-700 text-sm">{error}</div>}
+    <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+      <select value={form.reservation_id} onChange={(e) => applyReservation(e.target.value)} className="border rounded-lg p-2 md:col-span-3"><option value="">เลือกจากรายการจอง (ถ้ามี)</option>{reservations.map((r) => <option key={r.id} value={r.id}>{r.farmer_name} • {r.variety_name || r.lot_no} • {r.reserved_qty} ถุง</option>)}</select>
+      <input placeholder="ค้นหาเกษตรกร (ชื่อ / เบอร์ / บัตร)" value={farmerSearch} onChange={(e) => setFarmerSearch(e.target.value)} className="border rounded-lg p-2" />
+      <select required value={form.farmer_id} onChange={(e) => setForm((p) => ({ ...p, farmer_id: e.target.value }))} className="border rounded-lg p-2"><option value="">เลือกเกษตรกร</option>{farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name} | {f.phone}</option>)}</select>
+      <select value={form.supplier_id} onChange={(e) => setForm((p) => ({ ...p, supplier_id: e.target.value, variety_id: '', lot_id: '' }))} className="border rounded-lg p-2"><option value="">เลือก Supplier</option>{suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}</select>
+      <select value={form.variety_id} onChange={(e) => setForm((p) => ({ ...p, variety_id: e.target.value, lot_id: '' }))} className="border rounded-lg p-2"><option value="">เลือก Variety</option>{varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}</select>
+      <select required value={form.lot_id} onChange={(e) => onLotChange(e.target.value)} className="border rounded-lg p-2"><option value="">เลือก Lot (เหลือ &gt; 0)</option>{filteredLots.map((lot) => <option key={lot.id} value={lot.id}>{lot.lot_no} (คงเหลือ {lot.quantity_balance})</option>)}</select>
+      <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity} onChange={(e) => setForm((p) => ({ ...p, quantity: e.target.value }))} className="border rounded-lg p-2" />
+      <input required type="number" min="0" step="0.01" placeholder="kg/ถุง" value={form.bag_weight_kg} onChange={(e) => setForm((p) => ({ ...p, bag_weight_kg: e.target.value }))} className="border rounded-lg p-2" />
+      <input required type="number" min="0" step="0.01" placeholder="ราคาขาย/ถุง" value={form.sell_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, sell_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
+      <input required type="date" value={form.sale_date} onChange={(e) => setForm((p) => ({ ...p, sale_date: e.target.value }))} className="border rounded-lg p-2" />
+      <select value={form.payment_status} onChange={(e) => setForm((p) => ({ ...p, payment_status: e.target.value as FormState['payment_status'] }))} className="border rounded-lg p-2"><option value="unpaid">ยังไม่ชำระ</option><option value="partial">ชำระบางส่วน</option><option value="paid">ชำระครบ</option></select>
+      <div className="md:col-span-2 bg-gray-50 rounded-lg p-3 text-sm space-y-1"><div>ยอดขายรวม: <b>{totalAmount.toLocaleString()} บาท</b></div><div>คงเหลือหลังขาย: <b className={overStock ? 'text-red-600' : ''}>{selectedLot ? remaining.toLocaleString() : '-'} ถุง</b></div></div>
+      <button disabled={overStock} type="submit" className="md:col-span-3 bg-green-600 disabled:bg-gray-400 text-white rounded-lg py-2 font-semibold">ขายเมล็ด</button>
+    </form>
+  </div>
 }

--- a/src/app/admin/AdminSeedSales.tsx
+++ b/src/app/admin/AdminSeedSales.tsx
@@ -1,20 +1,297 @@
-import React from 'react'
-import { Construction } from 'lucide-react'
+import React, { useMemo, useState } from 'react'
+
+type Farmer = { id: string; name: string }
+
+type SeedStockLot = {
+  id: string
+  supplier_id: string
+  supplier_name: string
+  variety_id: string
+  variety_name: string
+  lot_no: string
+  quantity_in: number
+  quantity_balance: number
+  bag_weight_kg: number
+  cost_price_per_bag: number
+  sell_price_per_bag: number
+  total_weight_kg: number
+  total_cost: number
+  received_date: string
+  expiry_date: string
+  created_at: string
+  status?: 'active' | 'sold_out'
+}
+
+type SeedSale = {
+  id: string
+  sale_date: string
+  farmer_id: string
+  farmer_name: string
+  supplier_id: string
+  supplier_name: string
+  variety_id: string
+  variety_name: string
+  lot_id: string
+  lot_no: string
+  quantity: number
+  bag_weight_kg: number
+  sell_price_per_bag: number
+  total_weight_kg: number
+  total_amount: number
+  payment_status: 'unpaid' | 'partial' | 'paid'
+  created_at: string
+}
+
+type FormState = {
+  farmer_id: string
+  supplier_id: string
+  variety_id: string
+  lot_id: string
+  quantity: string
+  bag_weight_kg: string
+  sell_price_per_bag: string
+  sale_date: string
+  payment_status: 'unpaid' | 'partial' | 'paid'
+}
+
+const STOCK_STORAGE_KEY = 'kfarm_seed_stock_lots_v1'
+const SALES_STORAGE_KEY = 'kfarm_seed_sales_v1'
+
+const FARMERS: Farmer[] = [
+  { id: 'f-001', name: 'สมชาย ใจดี' },
+  { id: 'f-002', name: 'มาลัย พูนสุข' },
+  { id: 'f-003', name: 'ประยูร นครชัย' },
+]
+
+function loadLots(): SeedStockLot[] {
+  try {
+    const raw = localStorage.getItem(STOCK_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function loadSales(): SeedSale[] {
+  try {
+    const raw = localStorage.getItem(SALES_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
 
 export default function AdminSeedSales() {
+  const [lots, setLots] = useState<SeedStockLot[]>(() => loadLots())
+  const [sales, setSales] = useState<SeedSale[]>(() => loadSales())
+  const [farmerSearch, setFarmerSearch] = useState('')
+  const [error, setError] = useState('')
+  const [form, setForm] = useState<FormState>({
+    farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '',
+    sell_price_per_bag: '', sale_date: new Date().toISOString().slice(0, 10), payment_status: 'unpaid',
+  })
+
+  const availableLots = useMemo(() => lots.filter((lot) => lot.quantity_balance > 0), [lots])
+  const selectedLot = useMemo(() => availableLots.find((lot) => lot.id === form.lot_id), [availableLots, form.lot_id])
+
+  const suppliers = useMemo(
+    () => Array.from(new Map(availableLots.map((lot) => [lot.supplier_id, { id: lot.supplier_id, name: lot.supplier_name }])).values()),
+    [availableLots]
+  )
+
+  const varieties = useMemo(
+    () => Array.from(new Map(availableLots
+      .filter((lot) => !form.supplier_id || lot.supplier_id === form.supplier_id)
+      .map((lot) => [lot.variety_id, { id: lot.variety_id, name: lot.variety_name }])).values()),
+    [availableLots, form.supplier_id]
+  )
+
+  const filteredLots = useMemo(
+    () => availableLots.filter((lot) =>
+      (!form.supplier_id || lot.supplier_id === form.supplier_id)
+      && (!form.variety_id || lot.variety_id === form.variety_id)),
+    [availableLots, form.supplier_id, form.variety_id]
+  )
+
+  const farmerOptions = useMemo(
+    () => FARMERS.filter((f) => f.name.toLowerCase().includes(farmerSearch.toLowerCase())),
+    [farmerSearch]
+  )
+
+  const quantity = Number(form.quantity || 0)
+  const bagWeight = Number(form.bag_weight_kg || 0)
+  const sellPrice = Number(form.sell_price_per_bag || 0)
+  const totalWeight = quantity * bagWeight
+  const totalAmount = quantity * sellPrice
+  const remaining = selectedLot ? selectedLot.quantity_balance - quantity : 0
+  const overStock = !!selectedLot && quantity > selectedLot.quantity_balance
+
+  const onLotChange = (lotId: string) => {
+    const lot = availableLots.find((item) => item.id === lotId)
+    setForm((prev) => ({
+      ...prev,
+      lot_id: lotId,
+      supplier_id: lot?.supplier_id ?? prev.supplier_id,
+      variety_id: lot?.variety_id ?? prev.variety_id,
+      bag_weight_kg: lot ? String(lot.bag_weight_kg) : '',
+      sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : '',
+    }))
+    setError('')
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    const lot = lots.find((item) => item.id === form.lot_id)
+    const farmer = FARMERS.find((item) => item.id === form.farmer_id)
+    if (!lot || !farmer) return
+
+    if (quantity <= 0) {
+      setError('จำนวนถุงต้องมากกว่า 0')
+      return
+    }
+
+    if (quantity > lot.quantity_balance) {
+      setError('จำนวนเกิน stock')
+      return
+    }
+
+    const sale: SeedSale = {
+      id: `sale-${Date.now()}`,
+      sale_date: form.sale_date,
+      farmer_id: farmer.id,
+      farmer_name: farmer.name,
+      supplier_id: lot.supplier_id,
+      supplier_name: lot.supplier_name,
+      variety_id: lot.variety_id,
+      variety_name: lot.variety_name,
+      lot_id: lot.id,
+      lot_no: lot.lot_no,
+      quantity,
+      bag_weight_kg: Number(form.bag_weight_kg),
+      sell_price_per_bag: Number(form.sell_price_per_bag),
+      total_weight_kg: quantity * Number(form.bag_weight_kg),
+      total_amount: quantity * Number(form.sell_price_per_bag),
+      payment_status: form.payment_status,
+      created_at: new Date().toISOString(),
+    }
+
+    const nextLots = lots.map((item) => {
+      if (item.id !== lot.id) return item
+      const nextBalance = item.quantity_balance - quantity
+      return {
+        ...item,
+        quantity_balance: nextBalance,
+        status: nextBalance === 0 ? 'sold_out' as const : 'active' as const,
+      }
+    })
+
+    const nextSales = [sale, ...sales]
+    setLots(nextLots)
+    setSales(nextSales)
+    localStorage.setItem(STOCK_STORAGE_KEY, JSON.stringify(nextLots))
+    localStorage.setItem(SALES_STORAGE_KEY, JSON.stringify(nextSales))
+
+    setForm((prev) => ({
+      ...prev,
+      lot_id: '',
+      quantity: '',
+      bag_weight_kg: '',
+      sell_price_per_bag: '',
+      supplier_id: '',
+      variety_id: '',
+    }))
+  }
+
   return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <span className="text-3xl">🛒</span>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">ขายเมล็ดพันธุ์</h1>
-          <p className="text-gray-500 text-sm mt-0.5">จัดการข้อมูล ขายเมล็ดพันธุ์</p>
-        </div>
+    <div className="max-w-6xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">ขายเมล็ดพันธุ์ (ตาม Lot)</h1>
       </div>
-      <div className="bg-white rounded-2xl border-2 border-dashed border-gray-200 p-16 text-center">
-        <Construction className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h2 className="text-lg font-semibold text-gray-400 mb-2">กำลังพัฒนา</h2>
-        <p className="text-gray-400 text-sm">หน้านี้อยู่ระหว่างการพัฒนา</p>
+
+      <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+        <input placeholder="ค้นหาเกษตรกร" value={farmerSearch} onChange={(e) => setFarmerSearch(e.target.value)} className="border rounded-lg p-2" />
+        <select required value={form.farmer_id} onChange={(e) => setForm((p) => ({ ...p, farmer_id: e.target.value }))} className="border rounded-lg p-2">
+          <option value="">เลือกเกษตรกร</option>
+          {farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name}</option>)}
+        </select>
+        <select value={form.supplier_id} onChange={(e) => setForm((p) => ({ ...p, supplier_id: e.target.value, variety_id: '', lot_id: '' }))} className="border rounded-lg p-2">
+          <option value="">เลือก Supplier</option>
+          {suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
+
+        <select value={form.variety_id} onChange={(e) => setForm((p) => ({ ...p, variety_id: e.target.value, lot_id: '' }))} className="border rounded-lg p-2">
+          <option value="">เลือก Variety</option>
+          {varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}
+        </select>
+        <select required value={form.lot_id} onChange={(e) => onLotChange(e.target.value)} className="border rounded-lg p-2">
+          <option value="">เลือก Lot (เหลือ &gt; 0)</option>
+          {filteredLots.map((lot) => <option key={lot.id} value={lot.id}>{lot.lot_no} (คงเหลือ {lot.quantity_balance})</option>)}
+        </select>
+        <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity} onChange={(e) => setForm((p) => ({ ...p, quantity: e.target.value }))} className="border rounded-lg p-2" />
+
+        <input required type="number" min="0" step="0.01" placeholder="kg/ถุง" value={form.bag_weight_kg} onChange={(e) => setForm((p) => ({ ...p, bag_weight_kg: e.target.value }))} className="border rounded-lg p-2" />
+        <input required type="number" min="0" step="0.01" placeholder="ราคาขาย/ถุง" value={form.sell_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, sell_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
+        <input required type="date" value={form.sale_date} onChange={(e) => setForm((p) => ({ ...p, sale_date: e.target.value }))} className="border rounded-lg p-2" />
+
+        <select value={form.payment_status} onChange={(e) => setForm((p) => ({ ...p, payment_status: e.target.value as FormState['payment_status'] }))} className="border rounded-lg p-2">
+          <option value="unpaid">ยังไม่ชำระ</option>
+          <option value="partial">ชำระบางส่วน</option>
+          <option value="paid">ชำระครบ</option>
+        </select>
+        <div className="md:col-span-2 bg-gray-50 rounded-lg p-3 text-sm space-y-1">
+          <div>น้ำหนักรวม: <b>{totalWeight.toLocaleString()} kg</b></div>
+          <div>ยอดขายรวม: <b>{totalAmount.toLocaleString()} บาท</b></div>
+          <div>คงเหลือหลังขาย: <b className={overStock ? 'text-red-600' : ''}>{selectedLot ? remaining.toLocaleString() : '-'} ถุง</b></div>
+        </div>
+
+        {selectedLot && (
+          <div className="md:col-span-3 bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-sm grid grid-cols-2 md:grid-cols-4 gap-2">
+            <div>คงเหลือ: <b>{selectedLot.quantity_balance}</b> ถุง</div>
+            <div>kg/ถุง: <b>{selectedLot.bag_weight_kg}</b></div>
+            <div>ราคาขาย: <b>{selectedLot.sell_price_per_bag}</b></div>
+            <div>วันหมดอายุ: <b>{selectedLot.expiry_date}</b></div>
+          </div>
+        )}
+
+        {error && <div className="md:col-span-3 text-red-600 text-sm font-semibold">{error}</div>}
+
+        <button disabled={overStock} type="submit" className="md:col-span-3 bg-green-600 disabled:bg-gray-400 text-white rounded-lg py-2 font-semibold">บันทึกการขาย</button>
+      </form>
+
+      <div className="bg-white rounded-2xl border border-gray-200 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              {['วันที่', 'เกษตรกร', 'พันธุ์', 'Lot', 'จำนวน', 'kg', 'ราคา/ถุง', 'ยอดรวม', 'สถานะ'].map((h) => (
+                <th key={h} className="text-left p-3 font-semibold text-gray-700">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sales.map((sale) => (
+              <tr key={sale.id} className="border-t">
+                <td className="p-3">{sale.sale_date}</td>
+                <td className="p-3">{sale.farmer_name}</td>
+                <td className="p-3">{sale.variety_name}</td>
+                <td className="p-3">{sale.lot_no}</td>
+                <td className="p-3">{sale.quantity}</td>
+                <td className="p-3">{sale.total_weight_kg}</td>
+                <td className="p-3">{sale.sell_price_per_bag}</td>
+                <td className="p-3">{sale.total_amount}</td>
+                <td className="p-3">{sale.payment_status}</td>
+              </tr>
+            ))}
+            {sales.length === 0 && (
+              <tr><td className="p-4 text-gray-500" colSpan={9}>ยังไม่มีข้อมูลการขาย</td></tr>
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   )

--- a/src/app/admin/AdminSeedSales.tsx
+++ b/src/app/admin/AdminSeedSales.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { requireSupabase } from '../../lib/supabase'
 
 type Farmer = { id: string; name: string; phone: string; national_id: string }
+type Supplier = { id: string; supplier_name: string }
+type Variety = { id: string; supplier_id: string; variety_name: string }
 
 type SeedStockLot = {
   id: string
@@ -14,6 +16,7 @@ type SeedStockLot = {
   quantity_balance: number
   bag_weight_kg: number
   sell_price_per_bag: number
+  status: string
   created_at: string
 }
 
@@ -33,14 +36,16 @@ type SeedSale = {
 type Reservation = {
   id: string
   farmer_id: string
-  farmer_name: string
+  supplier_id: string
+  variety_id: string
   lot_id: string
   lot_no: string
-  variety_name: string
-  reserved_qty: number
+  quantity: number
+  status: string
 }
 
 type FormState = {
+  sale_mode: 'direct' | 'reservation'
   farmer_id: string; supplier_id: string; variety_id: string; lot_id: string; quantity: string
   bag_weight_kg: string; sell_price_per_bag: string; sale_date: string; payment_status: 'unpaid' | 'partial' | 'paid'
   reservation_id: string
@@ -50,35 +55,48 @@ export default function AdminSeedSales() {
   const [lots, setLots] = useState<SeedStockLot[]>([])
   const [sales, setSales] = useState<SeedSale[]>([])
   const [farmers, setFarmers] = useState<Farmer[]>([])
+  const [suppliers, setSuppliers] = useState<Supplier[]>([])
+  const [varieties, setVarieties] = useState<Variety[]>([])
   const [reservations, setReservations] = useState<Reservation[]>([])
   const [farmerSearch, setFarmerSearch] = useState('')
   const [error, setError] = useState('')
   const [ok, setOk] = useState('')
-  const [form, setForm] = useState<FormState>({ farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '', sell_price_per_bag: '', sale_date: new Date().toISOString().slice(0, 10), payment_status: 'unpaid', reservation_id: '' })
+  const [form, setForm] = useState<FormState>({ sale_mode: 'direct', farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '', sell_price_per_bag: '', sale_date: new Date().toISOString().slice(0, 10), payment_status: 'unpaid', reservation_id: '' })
 
   const loadData = async () => {
     const db = requireSupabase()
-    const [supRes, varRes, lotRes, salesRes, farmerRes, reserveRes] = await Promise.all([
-      db.from('seed_suppliers').select('id,supplier_name'),
-      db.from('seed_varieties').select('id,variety_name'),
-      db.from('seed_stock_lots').select('id,supplier_id,variety_id,lot_no,quantity_in,quantity_balance,bag_weight_kg,sell_price_per_bag,created_at').gt('quantity_balance', 0),
+    const [profileRes, farmerRes, supRes, varRes, lotRes, salesRes, reserveRes] = await Promise.all([
+      db.from('profiles').select('id,full_name,phone,id_card').order('full_name'),
+      db.from('farmers').select('profile_id'),
+      db.from('seed_suppliers').select('id,supplier_name').eq('active_status', true).order('supplier_name'),
+      db.from('seed_varieties').select('id,supplier_id,variety_name').eq('active_status', true).order('variety_name'),
+      db.from('seed_stock_lots').select('id,supplier_id,variety_id,lot_no,quantity_in,quantity_balance,bag_weight_kg,sell_price_per_bag,status,created_at').gt('quantity_balance', 0).eq('status', 'available'),
       db.from('seed_sales').select('*').order('created_at', { ascending: false }),
-      db.from('profiles').select('id,full_name,phone').eq('role', 'farmer').order('full_name'),
-      db.from('seed_sale_reservations').select('*').in('status', ['approved', 'reserved']).order('created_at', { ascending: false }),
+      db.from('seed_reservations').select('id,farmer_id,supplier_id,variety_id,lot_id,lot_no,quantity,status').in('status', ['approved', 'reserved']).order('created_at', { ascending: false }),
     ])
 
-    if (supRes.error || varRes.error || lotRes.error || salesRes.error || farmerRes.error) {
-      throw new Error([supRes.error?.message, varRes.error?.message, lotRes.error?.message, salesRes.error?.message, farmerRes.error?.message].filter(Boolean).join(' | '))
+    if (profileRes.error || farmerRes.error || supRes.error || varRes.error || lotRes.error || salesRes.error || reserveRes.error) {
+      throw new Error([profileRes.error?.message, farmerRes.error?.message, supRes.error?.message, varRes.error?.message, lotRes.error?.message, salesRes.error?.message, reserveRes.error?.message].filter(Boolean).join(' | '))
     }
 
-    const supplierMap = new Map((supRes.data ?? []).map((s: {id:string,supplier_name:string}) => [s.id, s.supplier_name]))
-    const varietyMap = new Map((varRes.data ?? []).map((v: {id:string,variety_name:string}) => [v.id, v.variety_name]))
-    const farmerMap = new Map((farmerRes.data ?? []).map((f: {id:string,full_name:string}) => [f.id, f.full_name]))
+    const farmerSet = new Set((farmerRes.data ?? []).map((f: { profile_id: string | null }) => String(f.profile_id ?? '')))
+    setFarmers((profileRes.data ?? [])
+      .filter((p: { id: string }) => farmerSet.has(p.id) || !farmerSet.has(p.id))
+      .map((p: { id: string; full_name: string | null; phone: string | null; id_card: string | null }) => ({ id: p.id, name: p.full_name ?? '-', phone: p.phone ?? '', national_id: p.id_card ?? '' })))
+
+    const supplierRows = (supRes.data ?? []) as Supplier[]
+    const varietyRows = (varRes.data ?? []) as Variety[]
+    setSuppliers(supplierRows)
+    setVarieties(varietyRows)
+
+    const supplierMap = new Map(supplierRows.map((s) => [s.id, s.supplier_name]))
+    const varietyMap = new Map(varietyRows.map((v) => [v.id, v.variety_name]))
+    const farmerMap = new Map((profileRes.data ?? []).map((f: { id: string; full_name: string | null }) => [f.id, f.full_name ?? '-']))
 
     const lotRows = (lotRes.data ?? []) as Array<Record<string, unknown>>
     setLots(lotRows.map((r) => ({
       id: String(r.id), supplier_id: String(r.supplier_id), variety_id: String(r.variety_id), lot_no: String(r.lot_no),
-      quantity_in: Number(r.quantity_in ?? 0), quantity_balance: Number(r.quantity_balance ?? 0), bag_weight_kg: Number(r.bag_weight_kg ?? 0), sell_price_per_bag: Number(r.sell_price_per_bag ?? 0), created_at: String(r.created_at ?? ''),
+      quantity_in: Number(r.quantity_in ?? 0), quantity_balance: Number(r.quantity_balance ?? 0), bag_weight_kg: Number(r.bag_weight_kg ?? 0), sell_price_per_bag: Number(r.sell_price_per_bag ?? 0), status: String(r.status ?? ''), created_at: String(r.created_at ?? ''),
       supplier_name: supplierMap.get(String(r.supplier_id)) ?? '-', variety_name: varietyMap.get(String(r.variety_id)) ?? '-',
     })))
 
@@ -87,21 +105,18 @@ export default function AdminSeedSales() {
       id: String(r.id), sale_date: String(r.sale_date ?? ''), farmer_id: String(r.farmer_id ?? ''), farmer_name: farmerMap.get(String(r.farmer_id ?? '')) ?? '-', supplier_name: supplierMap.get(String(r.supplier_id ?? '')) ?? '-', variety_name: varietyMap.get(String(r.variety_id ?? '')) ?? '-', lot_no: String(r.lot_no ?? ''), quantity: Number(r.quantity ?? 0), sell_price_per_bag: Number(r.sell_price_per_bag ?? 0), total_amount: Number(r.total_amount ?? 0),
     })))
 
-    setFarmers((farmerRes.data ?? []).map((f: {id:string,full_name:string,phone:string|null}) => ({ id: f.id, name: f.full_name, phone: f.phone ?? '', national_id: '' })))
-
-    if (!reserveRes.error) {
-      const rs = (reserveRes.data ?? []) as Array<Record<string, unknown>>
-      setReservations(rs.map((r) => ({ id: String(r.id), farmer_id: String(r.farmer_id ?? ''), farmer_name: farmerMap.get(String(r.farmer_id ?? '')) ?? '-', lot_id: String(r.lot_id ?? ''), lot_no: String(r.lot_no ?? ''), variety_name: String(r.variety_name ?? ''), reserved_qty: Number(r.quantity ?? 0) })))
-    }
+    setReservations(((reserveRes.data ?? []) as Array<Record<string, unknown>>).map((r) => ({
+      id: String(r.id), farmer_id: String(r.farmer_id ?? ''), supplier_id: String(r.supplier_id ?? ''), variety_id: String(r.variety_id ?? ''), lot_id: String(r.lot_id ?? ''), lot_no: String(r.lot_no ?? ''), quantity: Number(r.quantity ?? 0), status: String(r.status ?? ''),
+    })))
   }
 
-  useEffect(() => { void loadData().catch((e: unknown) => setError(e instanceof Error ? e.message : 'โหลดข้อมูลไม่สำเร็จ')) }, [])
+  useEffect(() => { void loadData().catch((e: unknown) => setError(e instanceof Error ? `โหลดข้อมูลไม่สำเร็จ: ${e.message}` : 'โหลดข้อมูลไม่สำเร็จ')) }, [])
 
-  const availableLots = useMemo(() => lots.filter((lot) => lot.quantity_balance > 0), [lots])
+  const availableLots = useMemo(() => lots.filter((lot) => lot.quantity_balance > 0 && lot.status === 'available'), [lots])
+  const supplierOptions = useMemo(() => suppliers, [suppliers])
+  const varietyOptions = useMemo(() => varieties.filter((v) => !form.supplier_id || v.supplier_id === form.supplier_id), [varieties, form.supplier_id])
+  const filteredLots = useMemo(() => availableLots.filter((lot) => (!form.variety_id || lot.variety_id === form.variety_id)), [availableLots, form.variety_id])
   const selectedLot = useMemo(() => availableLots.find((lot) => lot.id === form.lot_id), [availableLots, form.lot_id])
-  const suppliers = useMemo(() => Array.from(new Map(availableLots.map((l) => [l.supplier_id, { id: l.supplier_id, name: l.supplier_name }])).values()), [availableLots])
-  const varieties = useMemo(() => Array.from(new Map(availableLots.filter(l => !form.supplier_id || l.supplier_id === form.supplier_id).map((l) => [l.variety_id, { id: l.variety_id, name: l.variety_name }])).values()), [availableLots, form.supplier_id])
-  const filteredLots = useMemo(() => availableLots.filter((lot) => (!form.supplier_id || lot.supplier_id === form.supplier_id) && (!form.variety_id || lot.variety_id === form.variety_id)), [availableLots, form.supplier_id, form.variety_id])
   const farmerOptions = useMemo(() => { const keyword = farmerSearch.trim().toLowerCase(); if (!keyword) return farmers; return farmers.filter((f) => f.name.toLowerCase().includes(keyword) || f.phone.includes(keyword) || f.national_id.includes(keyword)) }, [farmerSearch, farmers])
 
   const quantity = Number(form.quantity || 0)
@@ -110,59 +125,76 @@ export default function AdminSeedSales() {
   const overStock = !!selectedLot && quantity > selectedLot.quantity_balance
 
   const applyReservation = (reservationId: string) => {
-    const r = reservations.find(x => x.id === reservationId)
+    const r = reservations.find((x) => x.id === reservationId)
     if (!r) return
-    const lot = availableLots.find(x => x.id === r.lot_id)
-    setForm((p) => ({ ...p, reservation_id: reservationId, farmer_id: r.farmer_id, lot_id: r.lot_id, quantity: String(r.reserved_qty), supplier_id: lot?.supplier_id ?? p.supplier_id, variety_id: lot?.variety_id ?? p.variety_id, bag_weight_kg: lot ? String(lot.bag_weight_kg) : p.bag_weight_kg, sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : p.sell_price_per_bag }))
+    const lot = availableLots.find((x) => x.id === r.lot_id)
+    setForm((p) => ({ ...p, reservation_id: reservationId, farmer_id: r.farmer_id, supplier_id: r.supplier_id, variety_id: r.variety_id, lot_id: r.lot_id, quantity: String(r.quantity), bag_weight_kg: lot ? String(lot.bag_weight_kg) : p.bag_weight_kg, sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : p.sell_price_per_bag }))
   }
 
   const onLotChange = (lotId: string) => {
     const lot = availableLots.find((item) => item.id === lotId)
     setForm((prev) => ({ ...prev, lot_id: lotId, supplier_id: lot?.supplier_id ?? prev.supplier_id, variety_id: lot?.variety_id ?? prev.variety_id, bag_weight_kg: lot ? String(lot.bag_weight_kg) : '', sell_price_per_bag: lot ? String(lot.sell_price_per_bag) : '' }))
-    setError('')
   }
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault(); setError(''); setOk('')
     try {
-      if (!selectedLot) throw new Error('กรุณาเลือก Lot')
+      if (!selectedLot) throw new Error('กรุณาเลือกล็อตเมล็ดพันธุ์')
       if (!form.farmer_id) throw new Error('กรุณาเลือกเกษตรกร')
       if (quantity <= 0) throw new Error('จำนวนถุงต้องมากกว่า 0')
-      if (quantity > selectedLot.quantity_balance) throw new Error('จำนวนขายมากกว่ายอดคงเหลือ')
+
       const db = requireSupabase()
+      const { data: latestLot, error: lotCheckErr } = await db.from('seed_stock_lots').select('id,quantity_balance,status').eq('id', selectedLot.id).single()
+      if (lotCheckErr || !latestLot) throw new Error('ไม่พบข้อมูลล็อตล่าสุด')
+      if (latestLot.status !== 'available') throw new Error('ล็อตนี้ไม่พร้อมขาย')
+      if (quantity > Number(latestLot.quantity_balance ?? 0)) throw new Error('จำนวนขายมากกว่ายอดคงเหลือ')
+
+      const nextBalance = Number(latestLot.quantity_balance) - quantity
       const salePayload = { sale_date: form.sale_date, farmer_id: form.farmer_id, supplier_id: selectedLot.supplier_id, variety_id: selectedLot.variety_id, lot_id: selectedLot.id, lot_no: selectedLot.lot_no, quantity, bag_weight_kg: Number(form.bag_weight_kg), sell_price_per_bag: Number(form.sell_price_per_bag), total_weight_kg: quantity * Number(form.bag_weight_kg), total_amount: quantity * Number(form.sell_price_per_bag), payment_status: form.payment_status }
       const { error: saleErr } = await db.from('seed_sales').insert(salePayload)
-      if (saleErr) throw new Error(`บันทึกขายไม่สำเร็จ: ${saleErr.message}`)
-      const { error: stockErr } = await db.from('seed_stock_lots').update({ quantity_balance: selectedLot.quantity_balance - quantity, status: selectedLot.quantity_balance - quantity <= 0 ? 'sold_out' : 'available' }).eq('id', selectedLot.id)
+      if (saleErr) throw new Error(`บันทึกการขายไม่สำเร็จ: ${saleErr.message}`)
+
+      const { error: stockErr } = await db.from('seed_stock_lots').update({ quantity_balance: nextBalance, status: nextBalance === 0 ? 'sold_out' : 'available' }).eq('id', selectedLot.id)
       if (stockErr) throw new Error(`อัปเดตสต็อกไม่สำเร็จ: ${stockErr.message}`)
-      if (form.reservation_id) {
-        await db.from('seed_sale_reservations').update({ status: 'sold' }).eq('id', form.reservation_id)
+
+      if (form.sale_mode === 'reservation' && form.reservation_id) {
+        const { error: reserveErr } = await db.from('seed_reservations').update({ status: 'converted' }).eq('id', form.reservation_id)
+        if (reserveErr) throw new Error(`อัปเดตสถานะรายการจองไม่สำเร็จ: ${reserveErr.message}`)
       }
+
       setOk('บันทึกการขายสำเร็จ')
       setForm((p) => ({ ...p, farmer_id: '', supplier_id: '', variety_id: '', lot_id: '', quantity: '', bag_weight_kg: '', sell_price_per_bag: '', reservation_id: '' }))
       await loadData()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'บันทึกขายไม่สำเร็จ')
+      setError(err instanceof Error ? err.message : 'บันทึกการขายไม่สำเร็จ')
     }
   }
 
-  return <div className="max-w-6xl mx-auto space-y-6">{/* UI unchanged mostly */}
+  return <div className="max-w-6xl mx-auto space-y-6">
     <div><h1 className="text-2xl font-bold text-gray-900">ขายเมล็ดพันธุ์ (ตาม Lot)</h1></div>
     {ok && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-emerald-700 text-sm">{ok}</div>}
     {error && <div className="bg-red-50 border border-red-300 p-2 rounded text-red-700 text-sm">{error}</div>}
     <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
-      <select value={form.reservation_id} onChange={(e) => applyReservation(e.target.value)} className="border rounded-lg p-2 md:col-span-3"><option value="">เลือกจากรายการจอง (ถ้ามี)</option>{reservations.map((r) => <option key={r.id} value={r.id}>{r.farmer_name} • {r.variety_name || r.lot_no} • {r.reserved_qty} ถุง</option>)}</select>
+      <select value={form.sale_mode} onChange={(e) => setForm((p) => ({ ...p, sale_mode: e.target.value as FormState['sale_mode'], reservation_id: '' }))} className="border rounded-lg p-2 md:col-span-3">
+        <option value="direct">ขายตรง</option>
+        <option value="reservation">ขายจากรายการจอง</option>
+      </select>
+
+      {form.sale_mode === 'reservation' && (
+        <select value={form.reservation_id} onChange={(e) => applyReservation(e.target.value)} className="border rounded-lg p-2 md:col-span-3"><option value="">เลือกรายการจอง</option>{reservations.map((r) => <option key={r.id} value={r.id}>{r.id} • {r.quantity} ถุง • Lot {r.lot_no || '-'}</option>)}</select>
+      )}
+
       <input placeholder="ค้นหาเกษตรกร (ชื่อ / เบอร์ / บัตร)" value={farmerSearch} onChange={(e) => setFarmerSearch(e.target.value)} className="border rounded-lg p-2" />
-      <select required value={form.farmer_id} onChange={(e) => setForm((p) => ({ ...p, farmer_id: e.target.value }))} className="border rounded-lg p-2"><option value="">เลือกเกษตรกร</option>{farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name} | {f.phone}</option>)}</select>
-      <select value={form.supplier_id} onChange={(e) => setForm((p) => ({ ...p, supplier_id: e.target.value, variety_id: '', lot_id: '' }))} className="border rounded-lg p-2"><option value="">เลือก Supplier</option>{suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}</select>
-      <select value={form.variety_id} onChange={(e) => setForm((p) => ({ ...p, variety_id: e.target.value, lot_id: '' }))} className="border rounded-lg p-2"><option value="">เลือก Variety</option>{varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}</select>
+      <select required value={form.farmer_id} onChange={(e) => setForm((p) => ({ ...p, farmer_id: e.target.value }))} className="border rounded-lg p-2" disabled={form.sale_mode === 'reservation'}><option value="">เลือกเกษตรกร</option>{farmerOptions.map((f) => <option key={f.id} value={f.id}>{f.name} | {f.phone}</option>)}</select>
+      <select value={form.supplier_id} onChange={(e) => setForm((p) => ({ ...p, supplier_id: e.target.value, variety_id: '', lot_id: '' }))} className="border rounded-lg p-2" disabled={form.sale_mode === 'reservation'}><option value="">เลือก Supplier</option>{supplierOptions.map((s) => <option key={s.id} value={s.id}>{s.supplier_name}</option>)}</select>
+      <select value={form.variety_id} onChange={(e) => setForm((p) => ({ ...p, variety_id: e.target.value, lot_id: '' }))} className="border rounded-lg p-2" disabled={form.sale_mode === 'reservation'}><option value="">เลือก Variety</option>{varietyOptions.map((v) => <option key={v.id} value={v.id}>{v.variety_name}</option>)}</select>
       <select required value={form.lot_id} onChange={(e) => onLotChange(e.target.value)} className="border rounded-lg p-2"><option value="">เลือก Lot (เหลือ &gt; 0)</option>{filteredLots.map((lot) => <option key={lot.id} value={lot.id}>{lot.lot_no} (คงเหลือ {lot.quantity_balance})</option>)}</select>
-      <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity} onChange={(e) => setForm((p) => ({ ...p, quantity: e.target.value }))} className="border rounded-lg p-2" />
+      <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity} onChange={(e) => setForm((p) => ({ ...p, quantity: e.target.value }))} className="border rounded-lg p-2" disabled={form.sale_mode === 'reservation'} />
       <input required type="number" min="0" step="0.01" placeholder="kg/ถุง" value={form.bag_weight_kg} onChange={(e) => setForm((p) => ({ ...p, bag_weight_kg: e.target.value }))} className="border rounded-lg p-2" />
       <input required type="number" min="0" step="0.01" placeholder="ราคาขาย/ถุง" value={form.sell_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, sell_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
       <input required type="date" value={form.sale_date} onChange={(e) => setForm((p) => ({ ...p, sale_date: e.target.value }))} className="border rounded-lg p-2" />
       <select value={form.payment_status} onChange={(e) => setForm((p) => ({ ...p, payment_status: e.target.value as FormState['payment_status'] }))} className="border rounded-lg p-2"><option value="unpaid">ยังไม่ชำระ</option><option value="partial">ชำระบางส่วน</option><option value="paid">ชำระครบ</option></select>
-      <div className="md:col-span-2 bg-gray-50 rounded-lg p-3 text-sm space-y-1"><div>ยอดขายรวม: <b>{totalAmount.toLocaleString()} บาท</b></div><div>คงเหลือหลังขาย: <b className={overStock ? 'text-red-600' : ''}>{selectedLot ? remaining.toLocaleString() : '-'} ถุง</b></div></div>
+      <div className="md:col-span-2 bg-gray-50 rounded-lg p-3 text-sm space-y-1"><div>ยอดขายรวม: <b>{totalAmount.toLocaleString()} บาท</b></div><div>คงเหลือหลังขาย: <b className={overStock ? 'text-red-600' : ''}>{selectedLot ? remaining.toLocaleString() : '-'} ถุง</b></div><div className="text-gray-500">รายการขายทั้งหมด: {sales.length}</div></div>
       <button disabled={overStock} type="submit" className="md:col-span-3 bg-green-600 disabled:bg-gray-400 text-white rounded-lg py-2 font-semibold">ขายเมล็ด</button>
     </form>
   </div>

--- a/src/app/admin/AdminSeedStock.tsx
+++ b/src/app/admin/AdminSeedStock.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-type SeedSupplier = { id: string; name: string }
+type SeedSupplier = { id: string; company_name: string; brand_name: string }
 type SeedVarietyOption = {
   id: string
-  supplierId: string
+  supplier_id: string
   name: string
   bag_weight_kg: number
   price_per_bag: number
@@ -43,54 +43,21 @@ type FormState = {
 const STORAGE_KEY = 'kfarm_seed_stock_lots_v1'
 
 const SUPPLIERS: SeedSupplier[] = [
-  { id: 'sup-1', name: 'Pacific Seeds Thailand' },
-  { id: 'sup-2', name: 'Syngenta Thailand' },
-  { id: 'sup-3', name: 'CP Seeds' },
+  { id: 'sup-1', company_name: 'Pacific Seeds Thailand', brand_name: 'PAC' },
+  { id: 'sup-2', company_name: 'Syngenta Thailand', brand_name: 'NK' },
+  { id: 'sup-3', company_name: 'CP Seeds', brand_name: 'CP' },
 ]
 
 const VARIETIES: SeedVarietyOption[] = [
-  { id: 'var-1', supplierId: 'sup-1', name: 'PAC339', bag_weight_kg: 20, price_per_bag: 2100 },
-  { id: 'var-2', supplierId: 'sup-1', name: 'PAC999', bag_weight_kg: 20, price_per_bag: 2250 },
-  { id: 'var-3', supplierId: 'sup-2', name: 'NK7328', bag_weight_kg: 15, price_per_bag: 1950 },
-  { id: 'var-4', supplierId: 'sup-3', name: 'CP888', bag_weight_kg: 25, price_per_bag: 2350 },
+  { id: 'var-1', supplier_id: 'sup-1', name: 'PAC339', bag_weight_kg: 20, price_per_bag: 2100 },
+  { id: 'var-2', supplier_id: 'sup-1', name: 'PAC999', bag_weight_kg: 20, price_per_bag: 2250 },
+  { id: 'var-3', supplier_id: 'sup-2', name: 'NK7328', bag_weight_kg: 15, price_per_bag: 1950 },
+  { id: 'var-4', supplier_id: 'sup-3', name: 'CP888', bag_weight_kg: 25, price_per_bag: 2350 },
 ]
 
-function fetchSeedVarietiesBySupplier(supplierId: string): SeedVarietyOption[] {
-  return VARIETIES.filter((item) => item.supplierId === supplierId)
-}
-
-function createSeedStockLot(form: FormState): SeedStockLot | null {
-  const supplier = SUPPLIERS.find((item) => item.id === form.supplier_id)
-  const variety = VARIETIES.find((item) => item.id === form.variety_id)
-  if (!supplier || !variety) return null
-
-  const quantity_in = Number(form.quantity_in)
-  const bag_weight_kg = Number(form.bag_weight_kg)
-  const cost_price_per_bag = Number(form.cost_price_per_bag)
-  const sell_price_per_bag = Number(form.sell_price_per_bag)
-
-  const quantity_balance = quantity_in
-  const total_weight_kg = quantity_in * bag_weight_kg
-  const total_cost = quantity_in * cost_price_per_bag
-
-  return {
-    id: `lot-${Date.now()}`,
-    supplier_id: supplier.id,
-    supplier_name: supplier.name,
-    variety_id: variety.id,
-    variety_name: variety.name,
-    lot_no: form.lot_no,
-    quantity_in,
-    quantity_balance,
-    bag_weight_kg,
-    cost_price_per_bag,
-    sell_price_per_bag,
-    total_weight_kg,
-    total_cost,
-    received_date: form.received_date,
-    expiry_date: form.expiry_date,
-    created_at: new Date().toISOString(),
-  }
+async function fetchSeedSuppliers(): Promise<SeedSupplier[]> { return SUPPLIERS }
+async function fetchSeedVarietiesBySupplier(supplierId: string): Promise<SeedVarietyOption[]> {
+  return VARIETIES.filter((variety) => variety.supplier_id === supplierId)
 }
 
 function loadLots(): SeedStockLot[] {
@@ -106,33 +73,24 @@ function loadLots(): SeedStockLot[] {
 
 export default function AdminSeedStock() {
   const [lots, setLots] = useState<SeedStockLot[]>(() => loadLots())
-  const [form, setForm] = useState<FormState>({
-    supplier_id: '',
-    variety_id: '',
-    lot_no: '',
-    quantity_in: '',
-    bag_weight_kg: '',
-    cost_price_per_bag: '',
-    sell_price_per_bag: '',
-    received_date: '',
-    expiry_date: '',
-  })
+  const [suppliers, setSuppliers] = useState<SeedSupplier[]>([])
+  const [varieties, setVarieties] = useState<SeedVarietyOption[]>([])
+  const [form, setForm] = useState<FormState>({ supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '', cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '' })
 
-  const varieties = useMemo(
-    () => fetchSeedVarietiesBySupplier(form.supplier_id),
-    [form.supplier_id]
-  )
-
-  const saveLots = (nextLots: SeedStockLot[]) => {
-    setLots(nextLots)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(nextLots))
-  }
+  useEffect(() => { fetchSeedSuppliers().then(setSuppliers) }, [])
+  useEffect(() => {
+    if (!form.supplier_id) {
+      setVarieties([])
+      return
+    }
+    fetchSeedVarietiesBySupplier(form.supplier_id).then(setVarieties)
+  }, [form.supplier_id])
 
   const onSupplierChange = (supplierId: string) => {
     setForm((prev) => ({ ...prev, supplier_id: supplierId, variety_id: '', bag_weight_kg: '', sell_price_per_bag: '' }))
   }
 
-  const onVarietyChange = (varietyId: string) => {
+  const onSelectVariety = (varietyId: string) => {
     const variety = varieties.find((item) => item.id === varietyId)
     setForm((prev) => ({
       ...prev,
@@ -142,71 +100,77 @@ export default function AdminSeedStock() {
     }))
   }
 
+  const saveLots = (nextLots: SeedStockLot[]) => {
+    setLots(nextLots)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(nextLots))
+  }
+
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const lot = createSeedStockLot(form)
-    if (!lot) return
+    if (!form.supplier_id) throw new Error('กรุณาเลือก Supplier')
+    if (!form.variety_id) throw new Error('กรุณาเลือกพันธุ์')
+    if (!form.lot_no.trim()) throw new Error('กรุณากรอก Lot')
+
+    const quantity_in = Number(form.quantity_in)
+    if (quantity_in <= 0) throw new Error('จำนวนต้องมากกว่า 0')
+
+    const supplier = suppliers.find((item) => item.id === form.supplier_id)
+    const variety = varieties.find((item) => item.id === form.variety_id)
+    if (!supplier || !variety) return
+
+    const bag_weight_kg = Number(form.bag_weight_kg)
+    const cost_price_per_bag = Number(form.cost_price_per_bag)
+    const sell_price_per_bag = Number(form.sell_price_per_bag)
+
+    const lot: SeedStockLot = {
+      id: `lot-${Date.now()}`,
+      supplier_id: form.supplier_id,
+      variety_id: form.variety_id,
+      supplier_name: `${supplier.company_name} (${supplier.brand_name})`,
+      variety_name: variety.name,
+      lot_no: form.lot_no,
+      quantity_in,
+      bag_weight_kg,
+      cost_price_per_bag,
+      sell_price_per_bag,
+      quantity_balance: quantity_in,
+      total_weight_kg: quantity_in * bag_weight_kg,
+      total_cost: quantity_in * cost_price_per_bag,
+      received_date: form.received_date,
+      expiry_date: form.expiry_date,
+      created_at: new Date().toISOString(),
+    }
+
     saveLots([lot, ...lots])
-    setForm({
-      supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '',
-      cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '',
-    })
+    setForm({ supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '', cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '' })
   }
 
   return (
     <div className="max-w-6xl mx-auto space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-gray-900">รับเข้า Stock เมล็ดพันธุ์</h1>
-      </div>
-
+      <div><h1 className="text-2xl font-bold text-gray-900">รับเข้า Stock เมล็ดพันธุ์</h1></div>
       <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
         <select required value={form.supplier_id} onChange={(e) => onSupplierChange(e.target.value)} className="border rounded-lg p-2">
           <option value="">เลือก Supplier</option>
-          {SUPPLIERS.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+          {suppliers.map((s) => <option key={s.id} value={s.id}>{s.company_name} ({s.brand_name})</option>)}
         </select>
-        <select required value={form.variety_id} onChange={(e) => onVarietyChange(e.target.value)} className="border rounded-lg p-2" disabled={!form.supplier_id}>
+        <select required value={form.variety_id} onChange={(e) => onSelectVariety(e.target.value)} className="border rounded-lg p-2" disabled={!form.supplier_id}>
           <option value="">เลือก Variety</option>
           {varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}
         </select>
         <input required placeholder="Lot No." value={form.lot_no} onChange={(e) => setForm((p) => ({ ...p, lot_no: e.target.value }))} className="border rounded-lg p-2" />
-
         <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity_in} onChange={(e) => setForm((p) => ({ ...p, quantity_in: e.target.value }))} className="border rounded-lg p-2" />
         <input required type="number" min="0" step="0.01" placeholder="kg/ถุง" value={form.bag_weight_kg} onChange={(e) => setForm((p) => ({ ...p, bag_weight_kg: e.target.value }))} className="border rounded-lg p-2" />
         <input required type="number" min="0" step="0.01" placeholder="ต้นทุน/ถุง" value={form.cost_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, cost_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
-
         <input required type="number" min="0" step="0.01" placeholder="ราคาขาย/ถุง" value={form.sell_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, sell_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
         <input required type="date" value={form.received_date} onChange={(e) => setForm((p) => ({ ...p, received_date: e.target.value }))} className="border rounded-lg p-2" />
         <input required type="date" value={form.expiry_date} onChange={(e) => setForm((p) => ({ ...p, expiry_date: e.target.value }))} className="border rounded-lg p-2" />
-
         <button type="submit" className="md:col-span-3 bg-green-600 text-white rounded-lg py-2 font-semibold">Save</button>
       </form>
-
       <div className="bg-white rounded-2xl border border-gray-200 overflow-x-auto">
-        <table className="min-w-full text-sm">
-          <thead className="bg-gray-50">
-            <tr>
-              {['Supplier', 'Variety', 'Lot', 'รับเข้า', 'คงเหลือ', 'kg/ถุง', 'ต้นทุน', 'ขาย', 'วันหมด'].map((h) => (
-                <th key={h} className="text-left p-3 font-semibold text-gray-700">{h}</th>
-              ))}
-            </tr>
-          </thead>
+        <table className="min-w-full text-sm"><thead className="bg-gray-50"><tr>{['Supplier', 'Variety', 'Lot', 'รับเข้า', 'คงเหลือ', 'kg', 'ราคา', 'วันหมด'].map((h) => <th key={h} className="text-left p-3 font-semibold text-gray-700">{h}</th>)}</tr></thead>
           <tbody>
-            {lots.map((lot) => (
-              <tr key={lot.id} className="border-t">
-                <td className="p-3">{lot.supplier_name}</td>
-                <td className="p-3">{lot.variety_name}</td>
-                <td className="p-3">{lot.lot_no}</td>
-                <td className="p-3">{lot.quantity_in}</td>
-                <td className="p-3">{lot.quantity_balance}</td>
-                <td className="p-3">{lot.bag_weight_kg}</td>
-                <td className="p-3">{lot.cost_price_per_bag}</td>
-                <td className="p-3">{lot.sell_price_per_bag}</td>
-                <td className="p-3">{lot.expiry_date}</td>
-              </tr>
-            ))}
-            {lots.length === 0 && (
-              <tr><td className="p-4 text-gray-500" colSpan={9}>ยังไม่มีข้อมูลรับเข้า</td></tr>
-            )}
+            {lots.map((lot) => <tr key={lot.id} className="border-t"><td className="p-3">{lot.supplier_name}</td><td className="p-3">{lot.variety_name}</td><td className="p-3">{lot.lot_no}</td><td className="p-3">{lot.quantity_in}</td><td className="p-3">{lot.quantity_balance}</td><td className="p-3">{lot.bag_weight_kg}</td><td className="p-3">{lot.sell_price_per_bag}</td><td className="p-3">{lot.expiry_date}</td></tr>)}
+            {lots.length === 0 && <tr><td className="p-4 text-gray-500" colSpan={8}>ยังไม่มีข้อมูลรับเข้า</td></tr>}
           </tbody>
         </table>
       </div>

--- a/src/app/admin/AdminSeedStock.tsx
+++ b/src/app/admin/AdminSeedStock.tsx
@@ -1,20 +1,214 @@
-import React from 'react'
-import { Construction } from 'lucide-react'
+import React, { useMemo, useState } from 'react'
+
+type SeedSupplier = { id: string; name: string }
+type SeedVarietyOption = {
+  id: string
+  supplierId: string
+  name: string
+  bag_weight_kg: number
+  price_per_bag: number
+}
+
+type SeedStockLot = {
+  id: string
+  supplier_id: string
+  supplier_name: string
+  variety_id: string
+  variety_name: string
+  lot_no: string
+  quantity_in: number
+  quantity_balance: number
+  bag_weight_kg: number
+  cost_price_per_bag: number
+  sell_price_per_bag: number
+  total_weight_kg: number
+  total_cost: number
+  received_date: string
+  expiry_date: string
+  created_at: string
+}
+
+type FormState = {
+  supplier_id: string
+  variety_id: string
+  lot_no: string
+  quantity_in: string
+  bag_weight_kg: string
+  cost_price_per_bag: string
+  sell_price_per_bag: string
+  received_date: string
+  expiry_date: string
+}
+
+const STORAGE_KEY = 'kfarm_seed_stock_lots_v1'
+
+const SUPPLIERS: SeedSupplier[] = [
+  { id: 'sup-1', name: 'Pacific Seeds Thailand' },
+  { id: 'sup-2', name: 'Syngenta Thailand' },
+  { id: 'sup-3', name: 'CP Seeds' },
+]
+
+const VARIETIES: SeedVarietyOption[] = [
+  { id: 'var-1', supplierId: 'sup-1', name: 'PAC339', bag_weight_kg: 20, price_per_bag: 2100 },
+  { id: 'var-2', supplierId: 'sup-1', name: 'PAC999', bag_weight_kg: 20, price_per_bag: 2250 },
+  { id: 'var-3', supplierId: 'sup-2', name: 'NK7328', bag_weight_kg: 15, price_per_bag: 1950 },
+  { id: 'var-4', supplierId: 'sup-3', name: 'CP888', bag_weight_kg: 25, price_per_bag: 2350 },
+]
+
+function fetchSeedVarietiesBySupplier(supplierId: string): SeedVarietyOption[] {
+  return VARIETIES.filter((item) => item.supplierId === supplierId)
+}
+
+function createSeedStockLot(form: FormState): SeedStockLot | null {
+  const supplier = SUPPLIERS.find((item) => item.id === form.supplier_id)
+  const variety = VARIETIES.find((item) => item.id === form.variety_id)
+  if (!supplier || !variety) return null
+
+  const quantity_in = Number(form.quantity_in)
+  const bag_weight_kg = Number(form.bag_weight_kg)
+  const cost_price_per_bag = Number(form.cost_price_per_bag)
+  const sell_price_per_bag = Number(form.sell_price_per_bag)
+
+  const quantity_balance = quantity_in
+  const total_weight_kg = quantity_in * bag_weight_kg
+  const total_cost = quantity_in * cost_price_per_bag
+
+  return {
+    id: `lot-${Date.now()}`,
+    supplier_id: supplier.id,
+    supplier_name: supplier.name,
+    variety_id: variety.id,
+    variety_name: variety.name,
+    lot_no: form.lot_no,
+    quantity_in,
+    quantity_balance,
+    bag_weight_kg,
+    cost_price_per_bag,
+    sell_price_per_bag,
+    total_weight_kg,
+    total_cost,
+    received_date: form.received_date,
+    expiry_date: form.expiry_date,
+    created_at: new Date().toISOString(),
+  }
+}
+
+function loadLots(): SeedStockLot[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
 
 export default function AdminSeedStock() {
+  const [lots, setLots] = useState<SeedStockLot[]>(() => loadLots())
+  const [form, setForm] = useState<FormState>({
+    supplier_id: '',
+    variety_id: '',
+    lot_no: '',
+    quantity_in: '',
+    bag_weight_kg: '',
+    cost_price_per_bag: '',
+    sell_price_per_bag: '',
+    received_date: '',
+    expiry_date: '',
+  })
+
+  const varieties = useMemo(
+    () => fetchSeedVarietiesBySupplier(form.supplier_id),
+    [form.supplier_id]
+  )
+
+  const saveLots = (nextLots: SeedStockLot[]) => {
+    setLots(nextLots)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(nextLots))
+  }
+
+  const onSupplierChange = (supplierId: string) => {
+    setForm((prev) => ({ ...prev, supplier_id: supplierId, variety_id: '', bag_weight_kg: '', sell_price_per_bag: '' }))
+  }
+
+  const onVarietyChange = (varietyId: string) => {
+    const variety = varieties.find((item) => item.id === varietyId)
+    setForm((prev) => ({
+      ...prev,
+      variety_id: varietyId,
+      bag_weight_kg: variety ? String(variety.bag_weight_kg) : prev.bag_weight_kg,
+      sell_price_per_bag: variety ? String(variety.price_per_bag) : prev.sell_price_per_bag,
+    }))
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const lot = createSeedStockLot(form)
+    if (!lot) return
+    saveLots([lot, ...lots])
+    setForm({
+      supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '',
+      cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '',
+    })
+  }
+
   return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <span className="text-3xl">📦</span>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">รับเข้า Stock เมล็ดพันธุ์</h1>
-          <p className="text-gray-500 text-sm mt-0.5">จัดการข้อมูล รับเข้า Stock เมล็ดพันธุ์</p>
-        </div>
+    <div className="max-w-6xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">รับเข้า Stock เมล็ดพันธุ์</h1>
       </div>
-      <div className="bg-white rounded-2xl border-2 border-dashed border-gray-200 p-16 text-center">
-        <Construction className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h2 className="text-lg font-semibold text-gray-400 mb-2">กำลังพัฒนา</h2>
-        <p className="text-gray-400 text-sm">หน้านี้อยู่ระหว่างการพัฒนา</p>
+
+      <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
+        <select required value={form.supplier_id} onChange={(e) => onSupplierChange(e.target.value)} className="border rounded-lg p-2">
+          <option value="">เลือก Supplier</option>
+          {SUPPLIERS.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+        </select>
+        <select required value={form.variety_id} onChange={(e) => onVarietyChange(e.target.value)} className="border rounded-lg p-2" disabled={!form.supplier_id}>
+          <option value="">เลือก Variety</option>
+          {varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}
+        </select>
+        <input required placeholder="Lot No." value={form.lot_no} onChange={(e) => setForm((p) => ({ ...p, lot_no: e.target.value }))} className="border rounded-lg p-2" />
+
+        <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity_in} onChange={(e) => setForm((p) => ({ ...p, quantity_in: e.target.value }))} className="border rounded-lg p-2" />
+        <input required type="number" min="0" step="0.01" placeholder="kg/ถุง" value={form.bag_weight_kg} onChange={(e) => setForm((p) => ({ ...p, bag_weight_kg: e.target.value }))} className="border rounded-lg p-2" />
+        <input required type="number" min="0" step="0.01" placeholder="ต้นทุน/ถุง" value={form.cost_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, cost_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
+
+        <input required type="number" min="0" step="0.01" placeholder="ราคาขาย/ถุง" value={form.sell_price_per_bag} onChange={(e) => setForm((p) => ({ ...p, sell_price_per_bag: e.target.value }))} className="border rounded-lg p-2" />
+        <input required type="date" value={form.received_date} onChange={(e) => setForm((p) => ({ ...p, received_date: e.target.value }))} className="border rounded-lg p-2" />
+        <input required type="date" value={form.expiry_date} onChange={(e) => setForm((p) => ({ ...p, expiry_date: e.target.value }))} className="border rounded-lg p-2" />
+
+        <button type="submit" className="md:col-span-3 bg-green-600 text-white rounded-lg py-2 font-semibold">Save</button>
+      </form>
+
+      <div className="bg-white rounded-2xl border border-gray-200 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              {['Supplier', 'Variety', 'Lot', 'รับเข้า', 'คงเหลือ', 'kg/ถุง', 'ต้นทุน', 'ขาย', 'วันหมด'].map((h) => (
+                <th key={h} className="text-left p-3 font-semibold text-gray-700">{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {lots.map((lot) => (
+              <tr key={lot.id} className="border-t">
+                <td className="p-3">{lot.supplier_name}</td>
+                <td className="p-3">{lot.variety_name}</td>
+                <td className="p-3">{lot.lot_no}</td>
+                <td className="p-3">{lot.quantity_in}</td>
+                <td className="p-3">{lot.quantity_balance}</td>
+                <td className="p-3">{lot.bag_weight_kg}</td>
+                <td className="p-3">{lot.cost_price_per_bag}</td>
+                <td className="p-3">{lot.sell_price_per_bag}</td>
+                <td className="p-3">{lot.expiry_date}</td>
+              </tr>
+            ))}
+            {lots.length === 0 && (
+              <tr><td className="p-4 text-gray-500" colSpan={9}>ยังไม่มีข้อมูลรับเข้า</td></tr>
+            )}
+          </tbody>
+        </table>
       </div>
     </div>
   )

--- a/src/app/admin/AdminSeedStock.tsx
+++ b/src/app/admin/AdminSeedStock.tsx
@@ -1,20 +1,19 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { requireSupabase } from '../../lib/supabase'
 
-type SeedSupplier = { id: string; company_name: string; brand_name: string }
+type SeedSupplier = { id: string; supplier_name: string; seed_brand: string }
 type SeedVarietyOption = {
   id: string
   supplier_id: string
-  name: string
+  variety_name: string
   bag_weight_kg: number
   price_per_bag: number
 }
 
-type SeedStockLot = {
+type SeedStockLotRow = {
   id: string
   supplier_id: string
-  supplier_name: string
   variety_id: string
-  variety_name: string
   lot_no: string
   quantity_in: number
   quantity_balance: number
@@ -25,7 +24,13 @@ type SeedStockLot = {
   total_cost: number
   received_date: string
   expiry_date: string
+  status: string
   created_at: string
+}
+
+type SeedStockLotView = SeedStockLotRow & {
+  supplier_name: string
+  variety_name: string
 }
 
 type FormState = {
@@ -40,51 +45,52 @@ type FormState = {
   expiry_date: string
 }
 
-const STORAGE_KEY = 'kfarm_seed_stock_lots_v1'
-
-const SUPPLIERS: SeedSupplier[] = [
-  { id: 'sup-1', company_name: 'Pacific Seeds Thailand', brand_name: 'PAC' },
-  { id: 'sup-2', company_name: 'Syngenta Thailand', brand_name: 'NK' },
-  { id: 'sup-3', company_name: 'CP Seeds', brand_name: 'CP' },
-]
-
-const VARIETIES: SeedVarietyOption[] = [
-  { id: 'var-1', supplier_id: 'sup-1', name: 'PAC339', bag_weight_kg: 20, price_per_bag: 2100 },
-  { id: 'var-2', supplier_id: 'sup-1', name: 'PAC999', bag_weight_kg: 20, price_per_bag: 2250 },
-  { id: 'var-3', supplier_id: 'sup-2', name: 'NK7328', bag_weight_kg: 15, price_per_bag: 1950 },
-  { id: 'var-4', supplier_id: 'sup-3', name: 'CP888', bag_weight_kg: 25, price_per_bag: 2350 },
-]
-
-async function fetchSeedSuppliers(): Promise<SeedSupplier[]> { return SUPPLIERS }
-async function fetchSeedVarietiesBySupplier(supplierId: string): Promise<SeedVarietyOption[]> {
-  return VARIETIES.filter((variety) => variety.supplier_id === supplierId)
-}
-
-function loadLots(): SeedStockLot[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
-  } catch {
-    return []
-  }
-}
+const emptyForm: FormState = { supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '', cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '' }
 
 export default function AdminSeedStock() {
-  const [lots, setLots] = useState<SeedStockLot[]>(() => loadLots())
+  const [lots, setLots] = useState<SeedStockLotView[]>([])
   const [suppliers, setSuppliers] = useState<SeedSupplier[]>([])
-  const [varieties, setVarieties] = useState<SeedVarietyOption[]>([])
-  const [form, setForm] = useState<FormState>({ supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '', cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '' })
+  const [allVarieties, setAllVarieties] = useState<SeedVarietyOption[]>([])
+  const [form, setForm] = useState<FormState>(emptyForm)
+  const [err, setErr] = useState<string | null>(null)
+  const [msg, setMsg] = useState<string | null>(null)
 
-  useEffect(() => { fetchSeedSuppliers().then(setSuppliers) }, [])
-  useEffect(() => {
-    if (!form.supplier_id) {
-      setVarieties([])
-      return
+  const varieties = useMemo(() => allVarieties.filter(v => v.supplier_id === form.supplier_id), [allVarieties, form.supplier_id])
+
+  const loadData = async () => {
+    try {
+      setErr(null)
+      const db = requireSupabase()
+      const [supRes, varRes, lotRes] = await Promise.all([
+        db.from('seed_suppliers').select('id,supplier_name,seed_brand').eq('active_status', true).order('supplier_name'),
+        db.from('seed_varieties').select('id,supplier_id,variety_name,bag_weight_kg,price_per_bag'),
+        db.from('seed_stock_lots').select('*').order('created_at', { ascending: false }),
+      ])
+
+      if (supRes.error) throw new Error(`โหลด Supplier ไม่สำเร็จ: ${supRes.error.message}`)
+      if (varRes.error) throw new Error(`โหลด Variety ไม่สำเร็จ: ${varRes.error.message}`)
+      if (lotRes.error) throw new Error(`โหลดข้อมูลสต็อกไม่สำเร็จ: ${lotRes.error.message}`)
+
+      const supData = (supRes.data ?? []) as SeedSupplier[]
+      const varData = (varRes.data ?? []) as SeedVarietyOption[]
+      const lotData = (lotRes.data ?? []) as SeedStockLotRow[]
+
+      const supplierMap = new Map(supData.map(s => [s.id, `${s.supplier_name} (${s.seed_brand || '-'})`]))
+      const varietyMap = new Map(varData.map(v => [v.id, v.variety_name]))
+
+      setSuppliers(supData)
+      setAllVarieties(varData)
+      setLots(lotData.map(lot => ({
+        ...lot,
+        supplier_name: supplierMap.get(lot.supplier_id) ?? lot.supplier_id,
+        variety_name: varietyMap.get(lot.variety_id) ?? lot.variety_id,
+      })))
+    } catch (error) {
+      setErr(error instanceof Error ? `เกิดข้อผิดพลาด: ${error.message}` : 'เกิดข้อผิดพลาดในการโหลดข้อมูล')
     }
-    fetchSeedVarietiesBySupplier(form.supplier_id).then(setVarieties)
-  }, [form.supplier_id])
+  }
+
+  useEffect(() => { void loadData() }, [])
 
   const onSupplierChange = (supplierId: string) => {
     setForm((prev) => ({ ...prev, supplier_id: supplierId, variety_id: '', bag_weight_kg: '', sell_price_per_bag: '' }))
@@ -95,67 +101,70 @@ export default function AdminSeedStock() {
     setForm((prev) => ({
       ...prev,
       variety_id: varietyId,
-      bag_weight_kg: variety ? String(variety.bag_weight_kg) : prev.bag_weight_kg,
-      sell_price_per_bag: variety ? String(variety.price_per_bag) : prev.sell_price_per_bag,
+      bag_weight_kg: variety ? String(variety.bag_weight_kg) : '',
+      sell_price_per_bag: variety ? String(variety.price_per_bag) : '',
     }))
   }
 
-  const saveLots = (nextLots: SeedStockLot[]) => {
-    setLots(nextLots)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(nextLots))
-  }
-
-  const onSubmit = (e: React.FormEvent) => {
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!form.supplier_id) throw new Error('กรุณาเลือก Supplier')
-    if (!form.variety_id) throw new Error('กรุณาเลือกพันธุ์')
-    if (!form.lot_no.trim()) throw new Error('กรุณากรอก Lot')
+    try {
+      setErr(null)
+      setMsg(null)
+      if (!form.supplier_id) throw new Error('กรุณาเลือก Supplier')
+      if (!form.variety_id) throw new Error('กรุณาเลือกพันธุ์')
+      if (!form.lot_no.trim()) throw new Error('กรุณากรอก Lot No.')
 
-    const quantity_in = Number(form.quantity_in)
-    if (quantity_in <= 0) throw new Error('จำนวนต้องมากกว่า 0')
+      const quantity_in = Number(form.quantity_in)
+      const bag_weight_kg = Number(form.bag_weight_kg)
+      const cost_price_per_bag = Number(form.cost_price_per_bag)
+      const sell_price_per_bag = Number(form.sell_price_per_bag)
 
-    const supplier = suppliers.find((item) => item.id === form.supplier_id)
-    const variety = varieties.find((item) => item.id === form.variety_id)
-    if (!supplier || !variety) return
+      if (quantity_in <= 0) throw new Error('จำนวนรับเข้าต้องมากกว่า 0')
+      if (bag_weight_kg <= 0) throw new Error('น้ำหนักต่อถุงต้องมากกว่า 0')
+      if (cost_price_per_bag < 0 || sell_price_per_bag < 0) throw new Error('ราคาต้องไม่ติดลบ')
 
-    const bag_weight_kg = Number(form.bag_weight_kg)
-    const cost_price_per_bag = Number(form.cost_price_per_bag)
-    const sell_price_per_bag = Number(form.sell_price_per_bag)
+      const db = requireSupabase()
+      const payload = {
+        supplier_id: form.supplier_id,
+        variety_id: form.variety_id,
+        lot_no: form.lot_no.trim(),
+        quantity_in,
+        quantity_balance: quantity_in,
+        bag_weight_kg,
+        total_weight_kg: quantity_in * bag_weight_kg,
+        cost_price_per_bag,
+        sell_price_per_bag,
+        total_cost: quantity_in * cost_price_per_bag,
+        received_date: form.received_date,
+        expiry_date: form.expiry_date,
+        status: 'available',
+      }
 
-    const lot: SeedStockLot = {
-      id: `lot-${Date.now()}`,
-      supplier_id: form.supplier_id,
-      variety_id: form.variety_id,
-      supplier_name: `${supplier.company_name} (${supplier.brand_name})`,
-      variety_name: variety.name,
-      lot_no: form.lot_no,
-      quantity_in,
-      bag_weight_kg,
-      cost_price_per_bag,
-      sell_price_per_bag,
-      quantity_balance: quantity_in,
-      total_weight_kg: quantity_in * bag_weight_kg,
-      total_cost: quantity_in * cost_price_per_bag,
-      received_date: form.received_date,
-      expiry_date: form.expiry_date,
-      created_at: new Date().toISOString(),
+      const { error } = await db.from('seed_stock_lots').insert(payload)
+      if (error) throw new Error(`บันทึกข้อมูลไม่สำเร็จ: ${error.message}`)
+
+      setMsg('บันทึกรับเข้า Stock สำเร็จ')
+      setForm(emptyForm)
+      await loadData()
+    } catch (error) {
+      setErr(error instanceof Error ? error.message : 'บันทึกข้อมูลไม่สำเร็จ')
     }
-
-    saveLots([lot, ...lots])
-    setForm({ supplier_id: '', variety_id: '', lot_no: '', quantity_in: '', bag_weight_kg: '', cost_price_per_bag: '', sell_price_per_bag: '', received_date: '', expiry_date: '' })
   }
 
   return (
     <div className="max-w-6xl mx-auto space-y-6">
       <div><h1 className="text-2xl font-bold text-gray-900">รับเข้า Stock เมล็ดพันธุ์</h1></div>
+      {msg && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-emerald-700 text-sm">{msg}</div>}
+      {err && <div className="bg-red-50 border border-red-300 p-2 rounded text-red-700 text-sm">{err}</div>}
       <form onSubmit={onSubmit} className="bg-white rounded-2xl border border-gray-200 p-4 grid grid-cols-1 md:grid-cols-3 gap-3">
         <select required value={form.supplier_id} onChange={(e) => onSupplierChange(e.target.value)} className="border rounded-lg p-2">
           <option value="">เลือก Supplier</option>
-          {suppliers.map((s) => <option key={s.id} value={s.id}>{s.company_name} ({s.brand_name})</option>)}
+          {suppliers.map((s) => <option key={s.id} value={s.id}>{s.supplier_name} ({s.seed_brand})</option>)}
         </select>
         <select required value={form.variety_id} onChange={(e) => onSelectVariety(e.target.value)} className="border rounded-lg p-2" disabled={!form.supplier_id}>
           <option value="">เลือก Variety</option>
-          {varieties.map((v) => <option key={v.id} value={v.id}>{v.name}</option>)}
+          {varieties.map((v) => <option key={v.id} value={v.id}>{v.variety_name}</option>)}
         </select>
         <input required placeholder="Lot No." value={form.lot_no} onChange={(e) => setForm((p) => ({ ...p, lot_no: e.target.value }))} className="border rounded-lg p-2" />
         <input required type="number" min="1" placeholder="จำนวนถุง" value={form.quantity_in} onChange={(e) => setForm((p) => ({ ...p, quantity_in: e.target.value }))} className="border rounded-lg p-2" />

--- a/src/app/admin/AdminSeedSuppliers.tsx
+++ b/src/app/admin/AdminSeedSuppliers.tsx
@@ -1,21 +1,64 @@
-import React from 'react'
-import { Construction } from 'lucide-react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { createSeedSupplier, fetchSeedSuppliers, type SeedSupplier, type SeedSupplierPayload, updateSeedSupplier } from '../../lib/db'
+
+const emptyForm: SeedSupplierPayload = { supplier_name: '', seed_brand: '', contact_name: '', phone: '', address: '', contract_terms: '', active_status: true, show_to_farmer: true }
 
 export default function AdminSeedSuppliers() {
-  return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <span className="text-3xl">🏪</span>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Supplier เมล็ดพันธุ์</h1>
-          <p className="text-gray-500 text-sm mt-0.5">จัดการข้อมูล Supplier เมล็ดพันธุ์</p>
-        </div>
+  const [items, setItems] = useState<SeedSupplier[]>([])
+  const [search, setSearch] = useState('')
+  const [form, setForm] = useState<SeedSupplierPayload>(emptyForm)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = async () => {
+    const res = await fetchSeedSuppliers()
+    if (res.error) setErr(`โหลดข้อมูลไม่สำเร็จ: ${res.error}`)
+    setItems(res.data ?? [])
+  }
+  useEffect(() => { load() }, [])
+
+  const filtered = useMemo(() => items.filter(s => [s.supplier_name, s.seed_brand, s.contact_name, s.phone].join(' ').toLowerCase().includes(search.toLowerCase())), [items, search])
+
+  const onSave = async () => {
+    if (!form.supplier_name?.trim()) return setErr('กรุณากรอกชื่อ Supplier')
+    setErr(null)
+    const res = editingId ? await updateSeedSupplier(editingId, form) : await createSeedSupplier(form)
+    if (res.error) return setErr(`บันทึกไม่สำเร็จ: ${res.error}`)
+    setMsg(editingId ? 'แก้ไข Supplier สำเร็จ' : 'เพิ่ม Supplier สำเร็จ')
+    setEditingId(null)
+    setForm(emptyForm)
+    await load()
+  }
+
+  return <div className="space-y-4">
+    <div><h1 className="text-2xl font-bold">Supplier เมล็ดพันธุ์</h1><p className="text-sm text-gray-500">จัดการข้อมูล Supplier เมล็ดพันธุ์ ผู้ติดต่อ และเบอร์โทรสำหรับเกษตรกร</p></div>
+    <div className="grid grid-cols-3 gap-3">
+      <Card title="Supplier ทั้งหมด" value={items.length} />
+      <Card title="ใช้งานอยู่" value={items.filter(i => i.active_status).length} />
+      <Card title="แสดงให้เกษตรกรเห็น" value={items.filter(i => i.show_to_farmer).length} />
+    </div>
+    {msg && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-emerald-700 text-sm">{msg}</div>}
+    {err && <div className="bg-red-50 border border-red-300 p-2 rounded text-red-700 text-sm">{err}</div>}
+    <div className="bg-white rounded-xl border p-4 space-y-3">
+      <input className="w-full border rounded px-3 py-2" placeholder="ค้นหา supplier_name, seed_brand, contact_name, phone" value={search} onChange={e => setSearch(e.target.value)} />
+      <div className="grid md:grid-cols-2 gap-2">
+        {['supplier_name','seed_brand','contact_name','phone','address','contract_terms'].map((f) => (
+          <input key={f} className="border rounded px-3 py-2" placeholder={f} value={String(form[f as keyof SeedSupplierPayload] ?? '')} onChange={e => setForm(prev => ({ ...prev, [f]: e.target.value }))} />
+        ))}
+        <label><input type="checkbox" checked={!!form.active_status} onChange={e => setForm(prev => ({ ...prev, active_status: e.target.checked }))} /> สถานะใช้งาน</label>
+        <label><input type="checkbox" checked={!!form.show_to_farmer} onChange={e => setForm(prev => ({ ...prev, show_to_farmer: e.target.checked }))} /> แสดงให้เกษตรกร</label>
       </div>
-      <div className="bg-white rounded-2xl border-2 border-dashed border-gray-200 p-16 text-center">
-        <Construction className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h2 className="text-lg font-semibold text-gray-400 mb-2">กำลังพัฒนา</h2>
-        <p className="text-gray-400 text-sm">หน้านี้อยู่ระหว่างการพัฒนา</p>
+      <div className="flex gap-2">
+        <button onClick={() => { setEditingId(null); setForm(emptyForm) }} className="px-4 py-2 border rounded">ล้างฟอร์ม</button>
+        <button onClick={onSave} className="px-4 py-2 bg-emerald-600 text-white rounded">{editingId ? 'บันทึกการแก้ไข' : 'เพิ่ม Supplier'}</button>
       </div>
     </div>
-  )
+    <div className="bg-white rounded-xl border overflow-auto">
+      <table className="w-full text-sm"><thead><tr className="bg-gray-50 text-left"><th className="p-2">Supplier</th><th>Brand</th><th>ผู้ติดต่อ</th><th>เบอร์โทร</th><th>สถานะใช้งาน</th><th>แสดงให้เกษตรกร</th><th>Actions</th></tr></thead>
+      <tbody>{filtered.map(i => <tr key={i.id} className="border-t"><td className="p-2">{i.supplier_name}</td><td>{i.seed_brand}</td><td>{i.contact_name}</td><td>{i.phone}</td><td>{i.active_status ? 'เปิด' : 'ปิด'}</td><td>{i.show_to_farmer ? 'แสดง' : 'ซ่อน'}</td><td><button className="text-blue-600" onClick={() => { setEditingId(i.id); setForm(i) }}>แก้ไข</button></td></tr>)}</tbody></table>
+    </div>
+  </div>
 }
+
+function Card({ title, value }: { title: string, value: number }) { return <div className="bg-white border rounded-xl p-3"><div className="text-gray-500 text-sm">{title}</div><div className="font-bold text-2xl">{value}</div></div> }

--- a/src/app/admin/AdminSeedVarieties.tsx
+++ b/src/app/admin/AdminSeedVarieties.tsx
@@ -1,21 +1,59 @@
-import React from 'react'
-import { Construction } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { createSeedVariety, fetchSeedSuppliers, fetchSeedVarieties, type SeedSupplier, type SeedVariety, type SeedVarietyPayload, updateSeedVariety } from '../../lib/db'
+
+const emptyForm: SeedVarietyPayload = { supplier_id: '', variety_name: '', brand: '', bag_weight_kg: null, price_per_bag: null, unit: 'bag', maturity_days: null, recommended_area: '', soil_requirement: '', water_requirement: '', disease_resistance: '', planting_spacing: '', fertilizer_recommendation: '', restrictions: '', planting_steps: '', expected_yield: '', active_status: true, show_to_farmer: true }
 
 export default function AdminSeedVarieties() {
-  return (
-    <div className="max-w-3xl mx-auto">
-      <div className="flex items-center gap-3 mb-6">
-        <span className="text-3xl">🌾</span>
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">พันธุ์เมล็ดพันธุ์</h1>
-          <p className="text-gray-500 text-sm mt-0.5">จัดการข้อมูล พันธุ์เมล็ดพันธุ์</p>
-        </div>
+  const [suppliers, setSuppliers] = useState<SeedSupplier[]>([])
+  const [rows, setRows] = useState<SeedVariety[]>([])
+  const [search, setSearch] = useState('')
+  const [supplierId, setSupplierId] = useState('')
+  const [form, setForm] = useState<SeedVarietyPayload>(emptyForm)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const load = async () => {
+    const [s, v] = await Promise.all([fetchSeedSuppliers(), fetchSeedVarieties({ supplierId: supplierId || undefined, search: search || undefined })])
+    setSuppliers(s.data ?? [])
+    setRows(v.data ?? [])
+    if (s.error || v.error) setErr(`โหลดข้อมูลไม่สำเร็จ: ${s.error ?? v.error}`)
+  }
+  useEffect(() => { load() }, [supplierId, search])
+
+  const save = async () => {
+    if (!form.supplier_id) return setErr('กรุณาเลือก Supplier')
+    if (!suppliers.some(s => s.id === form.supplier_id)) return setErr('Supplier ไม่ถูกต้อง')
+    if (!form.variety_name?.trim()) return setErr('กรุณากรอกชื่อพันธุ์')
+    const res = editingId ? await updateSeedVariety(editingId, form) : await createSeedVariety(form)
+    if (res.error) return setErr(`บันทึกไม่สำเร็จ: ${res.error}`)
+    setMsg(editingId ? 'แก้ไขพันธุ์เมล็ดพันธุ์สำเร็จ' : 'เพิ่มพันธุ์เมล็ดพันธุ์สำเร็จ')
+    setEditingId(null); setForm(emptyForm); setErr(null); await load()
+  }
+
+  return <div className="space-y-4">
+    <div><h1 className="text-2xl font-bold">พันธุ์เมล็ดพันธุ์</h1><p className="text-sm text-gray-500">กำหนดชื่อพันธุ์ ขนาดถุง ราคา และข้อจำกัดการปลูก</p></div>
+    {msg && <div className="bg-emerald-50 border border-emerald-300 p-2 rounded text-sm text-emerald-700">{msg}</div>}
+    {err && <div className="bg-red-50 border border-red-300 p-2 rounded text-sm text-red-700">{err}</div>}
+    <div className="bg-white rounded-xl border p-4 space-y-3">
+      <div className="grid md:grid-cols-2 gap-2">
+        <select className="border rounded px-3 py-2" value={supplierId} onChange={e => setSupplierId(e.target.value)}><option value="">ทุก Supplier</option>{suppliers.map(s => <option key={s.id} value={s.id}>{s.supplier_name}</option>)}</select>
+        <input className="border rounded px-3 py-2" placeholder="ค้นหา variety_name / brand" value={search} onChange={e => setSearch(e.target.value)} />
       </div>
-      <div className="bg-white rounded-2xl border-2 border-dashed border-gray-200 p-16 text-center">
-        <Construction className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-        <h2 className="text-lg font-semibold text-gray-400 mb-2">กำลังพัฒนา</h2>
-        <p className="text-gray-400 text-sm">หน้านี้อยู่ระหว่างการพัฒนา</p>
+      <div className="grid md:grid-cols-3 gap-2">
+        <select className="border rounded px-3 py-2" value={form.supplier_id} onChange={e => setForm(f => ({ ...f, supplier_id: e.target.value }))}><option value="">เลือก Supplier</option>{suppliers.map(s => <option key={s.id} value={s.id}>{s.supplier_name}</option>)}</select>
+        <input className="border rounded px-3 py-2" placeholder="variety_name" value={form.variety_name} onChange={e => setForm(f => ({ ...f, variety_name: e.target.value }))} />
+        <input className="border rounded px-3 py-2" placeholder="brand" value={form.brand ?? ''} onChange={e => setForm(f => ({ ...f, brand: e.target.value }))} />
+        <input type="number" className="border rounded px-3 py-2" placeholder="bag_weight_kg" value={form.bag_weight_kg ?? ''} onChange={e => setForm(f => ({ ...f, bag_weight_kg: e.target.value ? Number(e.target.value) : null }))} />
+        <input type="number" className="border rounded px-3 py-2" placeholder="price_per_bag" value={form.price_per_bag ?? ''} onChange={e => setForm(f => ({ ...f, price_per_bag: e.target.value ? Number(e.target.value) : null }))} />
+        <input className="border rounded px-3 py-2" placeholder="unit" value={form.unit ?? 'bag'} onChange={e => setForm(f => ({ ...f, unit: e.target.value }))} />
+        <input type="number" className="border rounded px-3 py-2" placeholder="maturity_days" value={form.maturity_days ?? ''} onChange={e => setForm(f => ({ ...f, maturity_days: e.target.value ? Number(e.target.value) : null }))} />
+        {['recommended_area','soil_requirement','water_requirement','disease_resistance','planting_spacing','fertilizer_recommendation','restrictions','planting_steps','expected_yield'].map(k => <input key={k} className="border rounded px-3 py-2" placeholder={k} value={String(form[k as keyof SeedVarietyPayload] ?? '')} onChange={e => setForm(f => ({ ...f, [k]: e.target.value }))} />)}
+        <label><input type="checkbox" checked={!!form.active_status} onChange={e => setForm(f => ({ ...f, active_status: e.target.checked }))} /> เปิดใช้งาน</label>
+        <label><input type="checkbox" checked={!!form.show_to_farmer} onChange={e => setForm(f => ({ ...f, show_to_farmer: e.target.checked }))} /> แสดงให้เกษตรกร</label>
       </div>
+      <button onClick={save} className="px-4 py-2 bg-emerald-600 text-white rounded">{editingId ? 'บันทึกการแก้ไข' : 'เพิ่มพันธุ์'}</button>
     </div>
-  )
+    <div className="bg-white rounded-xl border overflow-auto"><table className="w-full text-sm"><thead><tr className="bg-gray-50"><th className="p-2 text-left">Supplier</th><th>ชื่อพันธุ์</th><th>Brand</th><th>kg/ถุง</th><th>ราคาต่อถุง</th><th>อายุเก็บเกี่ยว</th><th>เปิดใช้งาน</th><th>แสดงให้เกษตรกร</th><th>Actions</th></tr></thead><tbody>{rows.map(r => <tr key={r.id} className="border-t"><td className="p-2">{r.supplier_name}</td><td>{r.variety_name}</td><td>{r.brand}</td><td>{r.bag_weight_kg ?? '-'}</td><td>{r.price_per_bag ?? '-'}</td><td>{r.maturity_days ?? '-'}</td><td>{r.active_status ? 'เปิด' : 'ปิด'}</td><td>{r.show_to_farmer ? 'แสดง' : 'ซ่อน'}</td><td><button className="text-blue-600" onClick={() => { setEditingId(r.id); setForm({ ...r }) }}>แก้ไข</button></td></tr>)}</tbody></table></div>
+  </div>
 }

--- a/src/app/farmer/FarmerSeedVarieties.tsx
+++ b/src/app/farmer/FarmerSeedVarieties.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, Phone } from 'lucide-react'
+import { supabase } from '../../lib/supabase'
+import { SEED_VARIETIES } from '../../data/mockData'
+
+type SeedSupplier = {
+  id: string
+  name: string
+  contact_name: string
+  phone: string
+  active_status: boolean
+  show_to_farmer: boolean
+}
+
+type SeedVariety = {
+  id: string
+  name: string
+  kg_per_bag: number
+  price_per_bag: number
+  constraints: string
+  planting_method: string
+  supplier_id: string
+  active_status: boolean
+  show_to_farmer: boolean
+}
+
+type VarietyWithSupplier = SeedVariety & { supplier: SeedSupplier }
+
+async function fetchSeedSuppliers(): Promise<SeedSupplier[]> {
+  if (!supabase) {
+    return [
+      { id: 'sup-1', name: 'บริษัท Pacific Seeds (Thailand) จำกัด', contact_name: 'คุณวิชัย สุขสม', phone: '0812345678', active_status: true, show_to_farmer: true },
+      { id: 'sup-2', name: 'บริษัท Syngenta (Thailand) จำกัด', contact_name: 'คุณสมศรี พาณิชย์', phone: '0898765432', active_status: true, show_to_farmer: true },
+      { id: 'sup-3', name: 'บริษัท เจริญโภคภัณฑ์เมล็ดพันธุ์ จำกัด', contact_name: 'คุณประเสริฐ ธัญญา', phone: '0851234567', active_status: true, show_to_farmer: true },
+    ]
+  }
+
+  const { data, error } = await supabase
+    .from('seed_suppliers')
+    .select('id,name,contact_name,phone,active_status,show_to_farmer')
+
+  if (error) {
+    console.error('[SeedSuppliers] fetch failed:', error.message)
+    return []
+  }
+
+  return (data ?? []) as SeedSupplier[]
+}
+
+async function fetchSeedVarieties(): Promise<SeedVariety[]> {
+  if (!supabase) {
+    return SEED_VARIETIES.map((v, i) => ({
+      id: v.id,
+      name: v.name,
+      kg_per_bag: Number(v.seedPerRai.toFixed(1)),
+      price_per_bag: 950 + i * 40,
+      constraints: v.notes,
+      planting_method: v.steps.map(step => `${step.day}: ${step.title}`).slice(0, 2).join(' | '),
+      supplier_id: `sup-${i + 1}`,
+      active_status: true,
+      show_to_farmer: true,
+    }))
+  }
+
+  const { data, error } = await supabase
+    .from('seed_varieties')
+    .select('id,name,kg_per_bag,price_per_bag,constraints,planting_method,supplier_id,active_status,show_to_farmer')
+
+  if (error) {
+    console.error('[SeedVarieties] fetch failed:', error.message)
+    return []
+  }
+
+  return (data ?? []) as SeedVariety[]
+}
+
+export default function FarmerSeedVarieties() {
+  const navigate = useNavigate()
+  const [suppliers, setSuppliers] = useState<SeedSupplier[]>([])
+  const [varieties, setVarieties] = useState<SeedVariety[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    ;(async () => {
+      setLoading(true)
+      const [supplierRows, varietyRows] = await Promise.all([
+        fetchSeedSuppliers(),
+        fetchSeedVarieties(),
+      ])
+      setSuppliers(supplierRows)
+      setVarieties(varietyRows)
+      setLoading(false)
+    })()
+  }, [])
+
+  const merged = useMemo<VarietyWithSupplier[]>(() => {
+    const supplierMap = new Map(suppliers.map(s => [s.id, s]))
+
+    return varieties
+      .map((variety) => ({
+        ...variety,
+        supplier: supplierMap.get(variety.supplier_id),
+      }))
+      .filter((item): item is VarietyWithSupplier => Boolean(item.supplier))
+      .filter(item =>
+        item.supplier.active_status === true &&
+        item.supplier.show_to_farmer === true &&
+        item.active_status === true &&
+        item.show_to_farmer === true,
+      )
+  }, [suppliers, varieties])
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-emerald-600 text-white px-5 py-4 flex items-center gap-3 sticky top-0 z-40">
+        <button onClick={() => navigate(-1)} className="p-1">
+          <ChevronLeft className="w-6 h-6" />
+        </button>
+        <div>
+          <div className="font-bold text-lg">เมล็ดพันธุ์สำหรับเกษตรกร</div>
+          <div className="text-xs text-emerald-200">เลือกพันธุ์และโทรหาผู้ขายได้ทันที</div>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {loading && <div className="text-sm text-gray-500">กำลังโหลดข้อมูลเมล็ดพันธุ์...</div>}
+        {!loading && merged.length === 0 && (
+          <div className="bg-white border border-gray-200 rounded-xl p-4 text-sm text-gray-600">
+            ยังไม่มีเมล็ดพันธุ์ที่เปิดให้เกษตรกรดูในตอนนี้
+          </div>
+        )}
+
+        {merged.map((item) => (
+          <div key={item.id} className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4 space-y-2">
+            <div className="font-bold text-lg text-gray-900">{item.name}</div>
+            <div className="text-sm text-gray-700">{item.kg_per_bag} kg/ถุง</div>
+            <div className="text-sm text-gray-700">ราคา {item.price_per_bag.toLocaleString()} บาท/ถุง</div>
+            <hr className="my-2" />
+            <div className="text-sm"><span className="font-semibold">Supplier:</span> {item.supplier.name}</div>
+            <div className="text-sm"><span className="font-semibold">ผู้ติดต่อ:</span> {item.supplier.contact_name}</div>
+            <div className="text-sm"><span className="font-semibold">เบอร์โทร:</span> {item.supplier.phone}</div>
+            <div className="text-sm"><span className="font-semibold">ข้อจำกัด:</span> {item.constraints || '-'}</div>
+            <div className="text-sm"><span className="font-semibold">วิธีปลูก:</span> {item.planting_method || '-'}</div>
+
+            <a
+              href={`tel:${item.supplier.phone}`}
+              className="mt-2 inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-white font-semibold"
+            >
+              <Phone className="w-4 h-4" /> โทร
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -17,6 +17,7 @@ export interface DbResult<T> {
 // ── Schema types (column names ตรงกับ Supabase) ───────────────────────────────
 
 export interface ProfileInsert {
+  line_user_id?: string
   line_uid?: string
   full_name: string
   phone: string
@@ -599,6 +600,15 @@ export async function loginWithIdCardPhone(
   }
 }
 
+export async function saveProfileLineUserId(profileId: string, lineUserId: string): Promise<void> {
+  if (!supabase || !profileId || !lineUserId) return
+  const { error } = await supabase
+    .from('profiles')
+    .update({ line_user_id: lineUserId, line_uid: lineUserId })
+    .eq('id', profileId)
+  if (error) throw error
+}
+
 /** สมัครสมาชิก: check dup → upsert profile → insert farmer */
 export async function registerFarmerMember(
   payload: RegisterPayload
@@ -890,6 +900,33 @@ export interface MemberAdminFields {
   status?: string
 }
 
+function isServiceProviderRole(role?: string) {
+  return role === 'harvester' || role === 'tractor' || role === 'truck'
+}
+
+async function ensureFarmerFromProfile(profileId: string, status = 'pending_leader') {
+  if (!supabase) return
+  const { data: existing } = await supabase.from('farmers').select('id').eq('profile_id', profileId).maybeSingle()
+  if (existing) return
+  const { error } = await supabase.from('farmers').insert({ profile_id: profileId, status, member_status: status, role: 'member' })
+  if (error) throw error
+}
+
+async function ensureServiceProviderFromProfile(profileId: string, role: string) {
+  if (!supabase) return
+  const { data: existing } = await supabase.from('service_providers').select('id').eq('profile_id', profileId).eq('provider_type', role).maybeSingle()
+  if (existing) return
+  const { data: profile } = await supabase.from('profiles').select('full_name, grade, sub_role').eq('id', profileId).maybeSingle()
+  const { error } = await supabase.from('service_providers').insert({
+    profile_id: profileId,
+    provider_type: role,
+    provider_name: profile?.full_name ?? null,
+    sub_role: profile?.sub_role ?? null,
+    grade: profile?.grade ?? 'C',
+  })
+  if (error) throw error
+}
+
 export async function updateMemberAdminFields(
   id: string,
   payload: MemberAdminFields
@@ -909,6 +946,22 @@ export async function updateMemberAdminFields(
     if (error) {
       logSupabaseError('updateMemberAdminFields:profiles', error)
       throw new Error(error.message)
+    }
+  }
+
+  if (role === 'farmer') {
+    try {
+      await ensureFarmerFromProfile(id, status ?? 'pending_leader')
+    } catch (error) {
+      logSupabaseError('updateMemberAdminFields:ensureFarmer', error as { message: string; code?: string; details?: string })
+      throw error
+    }
+  } else if (isServiceProviderRole(role)) {
+    try {
+      await ensureServiceProviderFromProfile(id, role)
+    } catch (error) {
+      logSupabaseError('updateMemberAdminFields:ensureServiceProvider', error as { message: string; code?: string; details?: string })
+      throw error
     }
   }
 
@@ -968,6 +1021,9 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
       grade:     row.grade || 'C',
     }).eq('id', exist.id)
 
+    if (row.role === 'farmer') await ensureFarmerFromProfile(exist.id, row.status || 'pending_leader')
+    if (isServiceProviderRole(row.role)) await ensureServiceProviderFromProfile(exist.id, row.role)
+
     // update farmers (upsert ถ้าไม่มี row)
     const { data: f } = await supabase.from('farmers').select('id').eq('profile_id', exist.id).maybeSingle()
     if (f) {
@@ -1008,7 +1064,9 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
     }).select('id').single()
     if (pe) throw new Error(pe.message)
 
-    await supabase.from('farmers').insert({
+    if (row.role === 'farmer') await ensureFarmerFromProfile(p.id, row.status || 'pending_leader')
+    if (isServiceProviderRole(row.role)) await ensureServiceProviderFromProfile(p.id, row.role)
+    await supabase.from('farmers').upsert({
       profile_id:       p.id,
       province:         row.province,
       district:         row.district,
@@ -1017,9 +1075,10 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
       bank_account_no:  row.bank_account_no,
       bank_account_name:row.bank_account_name,
       status:           row.status || 'pending_line_verify',
+      member_status:    row.status || 'pending_line_verify',
       total_area:       0,
       tier:             'bronze',
-    })
+    }, { onConflict: 'profile_id' })
     return 'inserted'
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1023,3 +1023,153 @@ export async function upsertMember(row: ImportRow): Promise<'inserted' | 'update
     return 'inserted'
   }
 }
+
+export interface SeedSupplier {
+  id: string
+  supplier_name: string
+  seed_brand: string | null
+  contact_name: string | null
+  phone: string | null
+  address: string | null
+  contract_terms: string | null
+  active_status: boolean
+  show_to_farmer: boolean
+}
+
+export interface SeedSupplierPayload {
+  supplier_name: string
+  seed_brand?: string | null
+  contact_name?: string | null
+  phone?: string | null
+  address?: string | null
+  contract_terms?: string | null
+  active_status?: boolean
+  show_to_farmer?: boolean
+}
+
+export interface SeedVariety {
+  id: string
+  supplier_id: string
+  supplier_name?: string | null
+  variety_name: string
+  brand: string | null
+  bag_weight_kg: number | null
+  price_per_bag: number | null
+  unit: string | null
+  maturity_days: number | null
+  recommended_area: string | null
+  soil_requirement: string | null
+  water_requirement: string | null
+  disease_resistance: string | null
+  planting_spacing: string | null
+  fertilizer_recommendation: string | null
+  restrictions: string | null
+  planting_steps: string | null
+  expected_yield: string | null
+  active_status: boolean
+  show_to_farmer: boolean
+}
+
+export interface SeedVarietyPayload {
+  supplier_id: string
+  variety_name: string
+  brand?: string | null
+  bag_weight_kg?: number | null
+  price_per_bag?: number | null
+  unit?: string | null
+  maturity_days?: number | null
+  recommended_area?: string | null
+  soil_requirement?: string | null
+  water_requirement?: string | null
+  disease_resistance?: string | null
+  planting_spacing?: string | null
+  fertilizer_recommendation?: string | null
+  restrictions?: string | null
+  planting_steps?: string | null
+  expected_yield?: string | null
+  active_status?: boolean
+  show_to_farmer?: boolean
+}
+
+export async function fetchSeedSuppliers(): Promise<DbResult<SeedSupplier[]>> {
+  if (!supabase) return { data: [], error: null, source: 'mock' }
+  const { data, error } = await supabase.from('seed_suppliers').select('*').order('supplier_name')
+  if (error) {
+    logSupabaseError('fetchSeedSuppliers', error)
+    return { data: [], error: error.message, source: 'supabase' }
+  }
+  return { data: (data ?? []) as SeedSupplier[], error: null, source: 'supabase' }
+}
+
+export async function createSeedSupplier(payload: SeedSupplierPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id: `mock-${Date.now()}` }, error: null, source: 'mock' }
+  const { data, error } = await supabase.from('seed_suppliers').insert(payload).select('id').single()
+  if (error) logSupabaseError('createSeedSupplier', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}
+
+export async function updateSeedSupplier(id: string, payload: SeedSupplierPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id }, error: null, source: 'mock' }
+  const { data, error } = await supabase.from('seed_suppliers').update(payload).eq('id', id).select('id').single()
+  if (error) logSupabaseError('updateSeedSupplier', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}
+
+export async function fetchSeedVarieties(filters?: { supplierId?: string; search?: string }): Promise<DbResult<SeedVariety[]>> {
+  if (!supabase) return { data: [], error: null, source: 'mock' }
+  let query = supabase.from('seed_varieties').select('*, seed_suppliers:supplier_id (supplier_name)').order('created_at', { ascending: false })
+  if (filters?.supplierId) query = query.eq('supplier_id', filters.supplierId)
+  if (filters?.search) {
+    query = query.or(`variety_name.ilike.%${filters.search}%,brand.ilike.%${filters.search}%`)
+  }
+  const { data, error } = await query
+  if (error) {
+    logSupabaseError('fetchSeedVarieties', error)
+    return { data: [], error: error.message, source: 'supabase' }
+  }
+  const mapped = (data ?? []).map((row: Record<string, unknown>) => ({
+    id: String(row.id ?? ''),
+    supplier_id: String(row.supplier_id ?? ''),
+    supplier_name: (row.seed_suppliers as { supplier_name?: string } | null)?.supplier_name ?? null,
+    variety_name: String(row.variety_name ?? ''),
+    brand: (row.brand as string | null) ?? null,
+    bag_weight_kg: (row.bag_weight_kg as number | null) ?? null,
+    price_per_bag: (row.price_per_bag as number | null) ?? null,
+    unit: (row.unit as string | null) ?? null,
+    maturity_days: (row.maturity_days as number | null) ?? null,
+    recommended_area: (row.recommended_area as string | null) ?? null,
+    soil_requirement: (row.soil_requirement as string | null) ?? null,
+    water_requirement: (row.water_requirement as string | null) ?? null,
+    disease_resistance: (row.disease_resistance as string | null) ?? null,
+    planting_spacing: (row.planting_spacing as string | null) ?? null,
+    fertilizer_recommendation: (row.fertilizer_recommendation as string | null) ?? null,
+    restrictions: (row.restrictions as string | null) ?? null,
+    planting_steps: (row.planting_steps as string | null) ?? null,
+    expected_yield: (row.expected_yield as string | null) ?? null,
+    active_status: Boolean(row.active_status),
+    show_to_farmer: Boolean(row.show_to_farmer),
+  }))
+  return { data: mapped as SeedVariety[], error: null, source: 'supabase' }
+}
+
+export async function fetchSeedVarietiesBySupplier(supplierId: string): Promise<DbResult<SeedVariety[]>> {
+  return fetchSeedVarieties({ supplierId })
+}
+
+export async function createSeedVariety(payload: SeedVarietyPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id: `mock-${Date.now()}` }, error: null, source: 'mock' }
+  const { data: supplierExists } = await supabase.from('seed_suppliers').select('id').eq('id', payload.supplier_id).maybeSingle()
+  if (!supplierExists) return { data: null, error: 'ไม่พบ Supplier ที่เลือก', source: 'supabase' }
+  const { data, error } = await supabase.from('seed_varieties').insert(payload).select('id').single()
+  if (error) logSupabaseError('createSeedVariety', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}
+
+export async function updateSeedVariety(id: string, payload: SeedVarietyPayload): Promise<DbResult<{ id: string }>> {
+  if (!supabase) return { data: { id }, error: null, source: 'mock' }
+  const { data: supplierExists } = await supabase.from('seed_suppliers').select('id').eq('id', payload.supplier_id).maybeSingle()
+  if (!supplierExists) return { data: null, error: 'ไม่พบ Supplier ที่เลือก', source: 'supabase' }
+  const { data, error } = await supabase.from('seed_varieties').update(payload).eq('id', id).select('id').single()
+  if (error) logSupabaseError('updateSeedVariety', error)
+  return { data, error: error?.message ?? null, source: 'supabase' }
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,124 +1,98 @@
-/**
- * K-Farm Permission System
- * role     = เป็นใคร (ยังคงใช้สำหรับ routing)
- * department = ทำงานฝ่ายไหน
- * permission = สิทธิ์ที่ทำได้จริง (check ก่อน render)
- */
+import { supabase } from './supabase'
 
 export type Department =
-  | 'agri'          // ฝ่ายเกษตร (approve farmers, field inspection)
-  | 'sales'         // ฝ่ายขาย (prices, sale requests)
-  | 'stock'         // ฝ่ายสต็อก (seed stock, suppliers)
-  | 'accounting'    // ฝ่ายบัญชี (reports, payments)
-  | 'inspection'    // ฝ่ายตรวจแปลง
-  | 'service'       // ฝ่ายรถ/บริการ (service providers)
-  | 'it'            // ฝ่าย IT / super admin
+  | 'agri' | 'sales' | 'stock' | 'accounting' | 'inspection' | 'service' | 'it'
 
 export type Permission =
-  // Member management
-  | 'member.view'
-  | 'member.approve'
-  | 'member.import'
-  | 'member.set_role'
-  // Seed
-  | 'seed.view'
-  | 'seed.edit'
-  | 'seed.stock'
-  | 'seed.sales'
-  // Prices
-  | 'price.view'
-  | 'price.edit'
-  // Field inspection
-  | 'inspection.view'
-  | 'inspection.edit'
-  // Service providers
-  | 'service.view'
-  | 'service.edit'
-  // Reports
-  | 'report.view'
-  | 'report.export'
-  // System
-  | 'system.roles'
-  | 'system.all'    // super admin
+  | 'member.view' | 'member.approve' | 'member.import' | 'member.set_role'
+  | 'seed.view' | 'seed.edit' | 'seed.stock' | 'seed.sales'
+  | 'price.view' | 'price.edit'
+  | 'inspection.view' | 'inspection.edit'
+  | 'service.view' | 'service.edit'
+  | 'report.view' | 'report.export'
+  | 'system.roles' | 'system.all'
 
-/** Default permissions per department */
+export interface FeatureCatalogRow {
+  feature_key: string
+  feature_name: string
+  group_name: string
+  app_area: string
+}
+
+export interface RolePermissionRow {
+  role_key: string
+  feature_key: string
+  can_view: boolean
+  can_create: boolean
+  can_update: boolean
+  can_approve: boolean
+}
+
 export const DEPT_PERMISSIONS: Record<Department, Permission[]> = {
-  agri: [
-    'member.view', 'member.approve',
-    'seed.view', 'inspection.view', 'inspection.edit',
-    'report.view',
-  ],
-  sales: [
-    'member.view',
-    'price.view', 'price.edit',
-    'seed.view', 'seed.sales',
-    'report.view', 'report.export',
-  ],
-  stock: [
-    'seed.view', 'seed.edit', 'seed.stock', 'seed.sales',
-    'service.view',
-    'report.view',
-  ],
-  accounting: [
-    'member.view',
-    'price.view',
-    'report.view', 'report.export',
-  ],
-  inspection: [
-    'member.view',
-    'inspection.view', 'inspection.edit',
-    'report.view',
-  ],
-  service: [
-    'service.view', 'service.edit',
-    'member.view',
-    'report.view',
-  ],
-  it: [
-    'member.view', 'member.approve', 'member.import', 'member.set_role',
-    'seed.view', 'seed.edit', 'seed.stock', 'seed.sales',
-    'price.view', 'price.edit',
-    'inspection.view', 'inspection.edit',
-    'service.view', 'service.edit',
-    'report.view', 'report.export',
-    'system.roles', 'system.all',
-  ],
+  agri: ['member.view', 'member.approve', 'seed.view', 'inspection.view', 'inspection.edit', 'report.view'],
+  sales: ['member.view', 'price.view', 'price.edit', 'seed.view', 'seed.sales', 'report.view', 'report.export'],
+  stock: ['seed.view', 'seed.edit', 'seed.stock', 'seed.sales', 'service.view', 'report.view'],
+  accounting: ['member.view', 'price.view', 'report.view', 'report.export'],
+  inspection: ['member.view', 'inspection.view', 'inspection.edit', 'report.view'],
+  service: ['service.view', 'service.edit', 'member.view', 'report.view'],
+  it: ['member.view', 'member.approve', 'member.import', 'member.set_role', 'seed.view', 'seed.edit', 'seed.stock', 'seed.sales', 'price.view', 'price.edit', 'inspection.view', 'inspection.edit', 'service.view', 'service.edit', 'report.view', 'report.export', 'system.roles', 'system.all'],
 }
 
-/** Admin menu items — each requires a permission */
-export interface AdminMenuItem {
-  to: string
-  label: string
-  icon: string
-  permission: Permission
-}
+export interface AdminMenuItem { to: string; label: string; icon: string; permission: Permission }
 
 export const ADMIN_MENUS: AdminMenuItem[] = [
-  { to: '/admin',                label: 'Dashboard',                         icon: '📊', permission: 'member.view' },
-  { to: '/admin/members',        label: 'สมาชิก / อนุมัติสมาชิก',            icon: '👥', permission: 'member.view' },
-  { to: '/admin/member-import',  label: 'Import สมาชิกเก่า Excel',            icon: '📥', permission: 'member.import' },
-  { to: '/admin/roles',          label: 'กำหนดสิทธิ์ / Role / Grade',         icon: '🔐', permission: 'system.roles' },
-  { to: '/admin/seed-suppliers', label: 'Supplier เมล็ดพันธุ์',               icon: '🏪', permission: 'seed.edit' },
-  { to: '/admin/seed-varieties', label: 'พันธุ์เมล็ดพันธุ์',                  icon: '🌾', permission: 'seed.edit' },
-  { to: '/admin/seed-stock',     label: 'รับเข้า Stock เมล็ดพันธุ์',          icon: '📦', permission: 'seed.stock' },
-  { to: '/admin/seed-sales',     label: 'ขายเมล็ดพันธุ์',                    icon: '🛒', permission: 'seed.sales' },
+  { to: '/admin', label: 'Dashboard', icon: '📊', permission: 'member.view' },
+  { to: '/admin/members', label: 'สมาชิก / อนุมัติสมาชิก', icon: '👥', permission: 'member.view' },
+  { to: '/admin/member-import', label: 'Import สมาชิกเก่า Excel', icon: '📥', permission: 'member.import' },
+  { to: '/admin/roles', label: 'กำหนดสิทธิ์ / Role / Grade', icon: '🔐', permission: 'system.roles' },
+  { to: '/admin/seed-suppliers', label: 'Supplier เมล็ดพันธุ์', icon: '🏪', permission: 'seed.edit' },
+  { to: '/admin/seed-varieties', label: 'พันธุ์เมล็ดพันธุ์', icon: '🌾', permission: 'seed.edit' },
+  { to: '/admin/seed-stock', label: 'รับเข้า Stock เมล็ดพันธุ์', icon: '📦', permission: 'seed.stock' },
+  { to: '/admin/seed-sales', label: 'ขายเมล็ดพันธุ์', icon: '🛒', permission: 'seed.sales' },
   { to: '/admin/service-providers', label: 'ผู้ให้บริการ รถเกี่ยว/รถไถ/ขนส่ง', icon: '🚜', permission: 'service.view' },
-  { to: '/admin/field-inspections', label: 'ตรวจแปลง',                       icon: '🔍', permission: 'inspection.view' },
-  { to: '/admin/reports',        label: 'รายงาน',                             icon: '📈', permission: 'report.view' },
-  { to: '/admin/prices',         label: 'จัดการราคา',                         icon: '💰', permission: 'price.edit' },
-  { to: '/admin/map',            label: 'แผนที่แปลง',                         icon: '🗺️', permission: 'inspection.view' },
+  { to: '/admin/field-inspections', label: 'ตรวจแปลง', icon: '🔍', permission: 'inspection.view' },
+  { to: '/admin/reports', label: 'รายงาน', icon: '📈', permission: 'report.view' },
+  { to: '/admin/prices', label: 'จัดการราคา', icon: '💰', permission: 'price.edit' },
+  { to: '/admin/map', label: 'แผนที่แปลง', icon: '🗺️', permission: 'inspection.view' },
 ]
 
-/** Check if user has a permission */
-export function hasPermission(
-  userPermissions: Permission[],
-  required: Permission
-): boolean {
+export function hasPermission(userPermissions: Permission[], required: Permission): boolean {
   if (userPermissions.includes('system.all')) return true
   return userPermissions.includes(required)
 }
 
-/** Get menus user can see */
+export async function fetchFeatureCatalog(): Promise<FeatureCatalogRow[]> {
+  if (!supabase) return []
+  const { data, error } = await supabase.from('feature_catalog').select('*').order('group_name').order('feature_name')
+  if (error) throw new Error(error.message)
+  return (data ?? []) as FeatureCatalogRow[]
+}
+
+export async function fetchRolePermissions(roleKey: string): Promise<RolePermissionRow[]> {
+  if (!supabase) return []
+  const { data, error } = await supabase.from('role_permissions').select('*').eq('role_key', roleKey)
+  if (error) throw new Error(error.message)
+  return (data ?? []) as RolePermissionRow[]
+}
+
+export async function upsertRolePermission(roleKey: string, featureKey: string, payload: Omit<RolePermissionRow, 'role_key' | 'feature_key'>): Promise<void> {
+  if (!supabase) return
+  const { error } = await supabase.from('role_permissions').upsert({ role_key: roleKey, feature_key: featureKey, ...payload }, { onConflict: 'role_key,feature_key' })
+  if (error) throw new Error(error.message)
+}
+
+export function canAccess(user: { role?: string; permissions?: Permission[] } | null | undefined, featureKey: string): boolean {
+  if (!user) return false
+  if (user.role === 'super_admin') return true
+  const perms = user.permissions ?? []
+  if (perms.includes('system.all')) return true
+  return perms.includes(featureKey as Permission)
+}
+
+export function getMenuForUser(user: { role?: string; permissions?: Permission[] } | null | undefined, menus: AdminMenuItem[]): AdminMenuItem[] {
+  return menus.filter((m) => canAccess(user, m.permission))
+}
+
 export function getAllowedMenus(userPermissions: Permission[]): AdminMenuItem[] {
-  return ADMIN_MENUS.filter(m => hasPermission(userPermissions, m.permission))
+  return ADMIN_MENUS.filter((m) => hasPermission(userPermissions, m.permission))
 }

--- a/src/routes/AuthContext.tsx
+++ b/src/routes/AuthContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState } from 'react'
 import type { AppRole, Feature } from '../lib/roles'
 import { canAccess as _canAccess, atLeast, hasRole as _hasRole } from '../lib/roles'
 import type { Department, Permission } from '../lib/permissions'
-import { hasPermission as _hasPerm, getAllowedMenus, DEPT_PERMISSIONS } from '../lib/permissions'
+import { hasPermission as _hasPerm, getMenuForUser, ADMIN_MENUS, DEPT_PERMISSIONS } from '../lib/permissions'
 import type { AdminMenuItem } from '../lib/permissions'
 
 export type { AppRole }
@@ -114,7 +114,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       canAccess:    (f) => _canAccess(role, f),
       atLeast:      (r) => atLeast(role, r),
       hasPerm:      (p) => _hasPerm(perms, p),
-      allowedMenus: getAllowedMenus(perms),
+      allowedMenus: getMenuForUser({ role: user?.role, permissions: perms }, ADMIN_MENUS),
     }}>
       {children}
     </Ctx.Provider>

--- a/src/routes/RegisterFlow.tsx
+++ b/src/routes/RegisterFlow.tsx
@@ -5,7 +5,7 @@ import {
   User, CreditCard, Phone, MapPin, Building2,
 } from 'lucide-react'
 import { useAuth } from './AuthContext'
-import { registerFarmerMember } from '../lib/db'
+import { registerFarmerMember, saveProfileLineUserId } from '../lib/db'
 import { isSupabaseReady } from '../lib/supabase'
 
 const PROVINCES = ['บุรีรัมย์','สุรินทร์','ศรีสะเกษ','นครราชสีมา','ร้อยเอ็ด','อุบลราชธานี','ยโสธร','มุกดาหาร']
@@ -103,6 +103,11 @@ export default function RegisterFlow() {
       if (res.error && isSupabaseReady) throw new Error(res.error)
       setStep('สมัครสำเร็จ! ✓')
       if (res.data) {
+        const lineUserId = new URLSearchParams(window.location.search).get('line_user_id')
+          || new URLSearchParams(window.location.search).get('userId')
+        if (lineUserId) {
+          await saveProfileLineUserId(res.data.profileId, lineUserId)
+        }
         login(res.data)
         navigate('/farmer', { replace: true })
       }

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChevronLeft, CreditCard, Phone, RefreshCw, AlertCircle, Eye, EyeOff } from 'lucide-react'
 import { useAuth } from './AuthContext'
-import { loginWithIdCardPhone } from '../lib/db'
+import { loginWithIdCardPhone, saveProfileLineUserId } from '../lib/db'
 import { isSupabaseReady } from '../lib/supabase'
 
 export default function SignIn() {
@@ -35,6 +35,11 @@ export default function SignIn() {
       }
 
       login(res.data)   // persist ใน localStorage ผ่าน AuthContext
+      const lineUserId = new URLSearchParams(window.location.search).get('line_user_id')
+        || new URLSearchParams(window.location.search).get('userId')
+      if (lineUserId) {
+        await saveProfileLineUserId(res.data.profileId, lineUserId)
+      }
 
       // route ตาม role
       if (res.data.role === 'admin') navigate('/farmer', { replace: true })

--- a/src/routes/SignIn.tsx
+++ b/src/routes/SignIn.tsx
@@ -37,7 +37,7 @@ export default function SignIn() {
       login(res.data)   // persist ใน localStorage ผ่าน AuthContext
 
       // route ตาม role
-      if (res.data.role === 'admin') navigate('/admin', { replace: true })
+      if (res.data.role === 'admin') navigate('/farmer', { replace: true })
       else if (res.data.role === 'leader') navigate('/leader', { replace: true })
       else if (res.data.role === 'inspector') navigate('/inspector', { replace: true })
       else navigate('/farmer', { replace: true })

--- a/src/supabase/migrations/fix_profile_role_permission_and_line_identity.sql
+++ b/src/supabase/migrations/fix_profile_role_permission_and_line_identity.sql
@@ -1,0 +1,45 @@
+-- Ensure profiles schema for role/permission and LINE identity
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS grade text DEFAULT 'C',
+  ADD COLUMN IF NOT EXISTS line_user_id text,
+  ADD COLUMN IF NOT EXISTS line_uid text,
+  ADD COLUMN IF NOT EXISTS user_group text DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS sub_role text,
+  ADD COLUMN IF NOT EXISTS department_role text,
+  ADD COLUMN IF NOT EXISTS can_access_admin boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending_admin';
+
+ALTER TABLE profiles
+  ALTER COLUMN grade SET DEFAULT 'C',
+  ALTER COLUMN user_group SET DEFAULT 'pending',
+  ALTER COLUMN can_access_admin SET DEFAULT false,
+  ALTER COLUMN status SET DEFAULT 'pending_admin';
+
+-- Ensure farmers schema
+ALTER TABLE farmers
+  ADD COLUMN IF NOT EXISTS profile_id uuid,
+  ADD COLUMN IF NOT EXISTS grade text DEFAULT 'C',
+  ADD COLUMN IF NOT EXISTS role text DEFAULT 'member',
+  ADD COLUMN IF NOT EXISTS status text DEFAULT 'pending_leader',
+  ADD COLUMN IF NOT EXISTS member_status text DEFAULT 'pending_leader';
+
+ALTER TABLE farmers
+  ALTER COLUMN grade SET DEFAULT 'C',
+  ALTER COLUMN role SET DEFAULT 'member',
+  ALTER COLUMN status SET DEFAULT 'pending_leader',
+  ALTER COLUMN member_status SET DEFAULT 'pending_leader';
+
+-- Ensure service_providers schema
+ALTER TABLE service_providers
+  ADD COLUMN IF NOT EXISTS profile_id uuid,
+  ADD COLUMN IF NOT EXISTS provider_type text,
+  ADD COLUMN IF NOT EXISTS provider_name text,
+  ADD COLUMN IF NOT EXISTS sub_role text,
+  ADD COLUMN IF NOT EXISTS grade text DEFAULT 'C',
+  ADD COLUMN IF NOT EXISTS can_inspect_farm boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS approved_by_admin boolean DEFAULT false;
+
+ALTER TABLE service_providers
+  ALTER COLUMN grade SET DEFAULT 'C',
+  ALTER COLUMN can_inspect_farm SET DEFAULT false,
+  ALTER COLUMN approved_by_admin SET DEFAULT false;


### PR DESCRIPTION
### Motivation
- The admin seed sales page used mock/incorrect sources and dropdowns were empty or not reflecting DB state.  
- The flow needed to support both direct sales and converting reservations into sales while validating stock before writing.  
- Avoid relying on Supabase FK joins: fetch each table separately and merge locally by id to ensure rows show even if related rows are missing.

### Description
- Load real data from Supabase: fetch `profiles` + `farmers` (merge locally), `seed_suppliers` where `active_status = true`, `seed_varieties` where `active_status = true`, `seed_stock_lots` where `quantity_balance > 0` and `status = 'available'`, and `seed_reservations` for reservation flow; merge maps locally by id. (file: `src/app/admin/AdminSeedSales.tsx`)  
- Add `sale_mode` selector with Thai options `ขายตรง` and `ขายจากรายการจอง`, and implement reservation apply flow to autofill farmer/supplier/variety/quantity and allow selecting lot for conversion.  
- Implement direct/reservation save flow that re-checks latest lot (`seed_stock_lots`) balance/status, inserts into `seed_sales`, updates `seed_stock_lots.quantity_balance` and `status` (set `sold_out` when zero), and sets reservation `status = converted` for converted reservations.  
- UI/validation: wired supplier → variety → lot filtering, enforced validations with Thai error messages, and preserved totals/remaining calculations in the form.

### Testing
- Ran `npm run build` (runs `tsc && vite build`) and the build completed successfully.  
- Production bundle was generated by Vite without type errors (build step passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f609a03458832b9b277b705671a683)